### PR TITLE
Ability to ignore elements when matching by body

### DIFF
--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -37,7 +38,7 @@ namespace EasyVCR.Tests
             const string censorString = "censored-by-test";
             var advancedSettings = new AdvancedSettings
             {
-                Censors = new Censors(censorString).HideHeaders(new List<string> { "Date" })
+                Censors = new Censors(censorString).HideHeaderKeys(new List<string> { "Date" })
             };
 
             // record cassette with advanced settings first
@@ -243,7 +244,7 @@ namespace EasyVCR.Tests
             // set up advanced settings
             const string censorString = "censored-by-test";
             var censors = new Censors(censorString);
-            censors.HideBodyParameters(new List<string> { "nested_dict_1_1_1", "nested_dict_2_2", "nested_array", "null_key" });
+            censors.HideBodyElementKeys(new List<string> { "nested_dict_1_1_1", "nested_dict_2_2", "nested_array", "null_key" });
             var advancedSettings = new AdvancedSettings
             {
                 Censors = censors
@@ -300,7 +301,7 @@ namespace EasyVCR.Tests
             const string censorString = "censored-by-test";
             var advancedSettings = new AdvancedSettings
             {
-                Censors = new Censors(censorString).HideBodyParameters(new List<string> { "Table" })
+                Censors = new Censors(censorString).HideBodyElementKeys(new List<string> { "Table" })
             };
 
             // record cassette with advanced settings first
@@ -315,6 +316,44 @@ namespace EasyVCR.Tests
 
             // TODO: Test is failing because the response is not being censored.
             // have to manually check cassette for the censored string in the response body
+        }
+
+        [TestMethod]
+        public async Task TextIgnoreElements()
+        {
+            var cassette = TestUtils.GetCassette("test_ignore_elements");
+            cassette.Erase(); // Erase cassette before recording
+
+            var bodyData1 = new StringContent("{\"name\": \"Jack Sparrow\",\n    \"company\": \"EasyPost\"}");
+            var bodyData2 = new StringContent("{\"name\": \"Different Name\",\n    \"company\": \"EasyPost\"}");
+
+            // record baseline request first
+            var client = HttpClients.NewHttpClient(cassette, Mode.Record);
+            var _ = await client.PostAsync(FakeDataService.GetExchangeRatesUrl("json"), bodyData1);
+
+            // try to replay the request with different body data
+            client = HttpClients.NewHttpClient(cassette, Mode.Replay, new AdvancedSettings
+            {
+                MatchRules = new MatchRules().ByBody().ByMethod().ByFullUrl()
+            });
+
+            // should fail since we're strictly in replay mode and there's no exact match
+            await Assert.ThrowsExceptionAsync<VCRException>(async () => await client.PostAsync(FakeDataService.GetExchangeRatesUrl("json"), bodyData2));
+
+            // try to replay the request with different body data, but ignoring the differences
+            var ignoreElements = new List<CensorElement>
+            {
+                new CensorElement("name", false)
+            };
+            client = HttpClients.NewHttpClient(cassette, Mode.Replay, new AdvancedSettings
+            {
+                MatchRules = new MatchRules().ByBody(ignoreElements).ByMethod().ByFullUrl()
+            });
+
+            // should succeed since we're ignoring the differences
+            var response = await client.PostAsync(FakeDataService.GetExchangeRatesUrl("json"), bodyData2);
+            Assert.IsNotNull(response);
+            Assert.IsTrue(Utilities.ResponseCameFromRecording(response));
         }
 
         private static async Task<ExchangeRates?> GetExchangeRatesRequest(Cassette cassette, Mode mode)

--- a/EasyVCR.Tests/FakeDataService.cs
+++ b/EasyVCR.Tests/FakeDataService.cs
@@ -66,9 +66,14 @@ namespace EasyVCR.Tests
 
         public async Task<HttpResponseMessage> GetExchangeRatesRawResponse()
         {
-            return await Client.GetAsync("http://api.nbp.pl/api/exchangerates/rates/a/gbp/last/10/?format=" + _format);
+            return await Client.GetAsync(GetExchangeRatesUrl(_format));
         }
 
         protected abstract ExchangeRates Convert(string responseBody);
+
+        public static string GetExchangeRatesUrl(string format)
+        {
+            return "https://api.nbp.pl/api/exchangerates/rates/a/gbp/last/10/?format=" + format;
+        }
     }
 }

--- a/EasyVCR.Tests/Sample.cs
+++ b/EasyVCR.Tests/Sample.cs
@@ -36,10 +36,15 @@ namespace EasyVCR.Tests
         /// </summary>
         public async Task AdvancedVCRExample()
         {
+            var bodyElementsToIgnoreDuringMatch = new List<CensorElement>()
+            {
+                { new CensorElement("name", true) },
+                { new CensorElement("phone", false) },
+            };
             var advancedSettings = new AdvancedSettings
             {
-                MatchRules = new MatchRules().ByBody().ByHeader("X-My-Header"), // Match recorded requests by body and a specific header
-                Censors = new Censors("redacted").HideHeaders(new List<string> { "Header-To-Hide" }).HideQueryParameters(new List<string> { "api_key" }), // Redact a specific header and query parameter 
+                MatchRules = new MatchRules().ByBody(bodyElementsToIgnoreDuringMatch).ByHeader("X-My-Header"), // Match recorded requests by body and a specific header
+                Censors = new Censors("redacted").HideHeaderKeys(new List<string> { "Header-To-Hide" }).HideQueryParameterKeys(new List<string> { "api_key" }), // Redact a specific header and query parameter 
                 ManualDelay = 1000, // Simulate a delay of 1 second
             };
             var order = new CassetteOrder.None(); // elements of each request in a cassette will not be ordered any particular way

--- a/EasyVCR.Tests/Sample.cs
+++ b/EasyVCR.Tests/Sample.cs
@@ -44,7 +44,7 @@ namespace EasyVCR.Tests
             var advancedSettings = new AdvancedSettings
             {
                 MatchRules = new MatchRules().ByBody(bodyElementsToIgnoreDuringMatch).ByHeader("X-My-Header"), // Match recorded requests by body and a specific header
-                Censors = new Censors("redacted").HideHeaderKeys(new List<string> { "Header-To-Hide" }).HideQueryParameterKeys(new List<string> { "api_key" }), // Redact a specific header and query parameter 
+                Censors = new Censors("redacted").CensorHeadersByKeys(new List<string> { "Header-To-Hide" }).CensorQueryParametersByKeys(new List<string> { "api_key" }), // Redact a specific header and query parameter 
                 ManualDelay = 1000, // Simulate a delay of 1 second
             };
             var order = new CassetteOrder.None(); // elements of each request in a cassette will not be ordered any particular way

--- a/EasyVCR.Tests/VCRTest.cs
+++ b/EasyVCR.Tests/VCRTest.cs
@@ -19,7 +19,7 @@ namespace EasyVCR.Tests
             const string censorString = "censored-by-test";
             var advancedSettings = new AdvancedSettings
             {
-                Censors = new Censors(censorString).HideHeaders(new List<string> { "Date" }),
+                Censors = new Censors(censorString).HideHeaderKeys(new List<string> { "Date" }),
             };
 
             var vcr = new VCR(advancedSettings);

--- a/EasyVCR.Tests/VCRTest.cs
+++ b/EasyVCR.Tests/VCRTest.cs
@@ -19,7 +19,7 @@ namespace EasyVCR.Tests
             const string censorString = "censored-by-test";
             var advancedSettings = new AdvancedSettings
             {
-                Censors = new Censors(censorString).HideHeaderKeys(new List<string> { "Date" }),
+                Censors = new Censors(censorString).CensorHeadersByKeys(new List<string> { "Date" }),
             };
 
             var vcr = new VCR(advancedSettings);

--- a/EasyVCR/CensorElement.cs
+++ b/EasyVCR/CensorElement.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace EasyVCR
+{
+    public class CensorElement
+    {
+        /// <summary>
+        ///     Whether the name is case-sensitive.
+        /// </summary>
+        private bool CaseSensitive { get; set; }
+        /// <summary>
+        ///     Name of the element to censor.
+        /// </summary>
+        private string Name { get; set; }
+
+        /// <summary>
+        ///     Constructor for a new censor element.
+        /// </summary>
+        /// <param name="name">Name of the element to censor.</param>
+        /// <param name="caseSensitive">Whether the name is case-sensitive.</param>
+        public CensorElement(string name, bool caseSensitive)
+        {
+            Name = name;
+            CaseSensitive = caseSensitive;
+        }
+
+        /// <summary>
+        ///     Checks whether the provided element matches this censor element, accounting for case sensitivity.
+        /// </summary>
+        /// <param name="key">The name to check.</param>
+        /// <returns>True if the element matches, false otherwise.</returns>
+        internal bool Matches(string key)
+        {
+            return CaseSensitive ? Name.Equals(key) : Name.Equals(key, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/EasyVCR/Censors.cs
+++ b/EasyVCR/Censors.cs
@@ -225,56 +225,77 @@ namespace EasyVCR
             return $"{uri.GetLeftPart(UriPartial.Path)}?{ToQueryString(censoredQueryParameters)}";
         }
 
-        public static string CensorJsonData(string body, string censorText, IReadOnlyCollection<CensorElement> elementsToCensors)
+        /// <summary>
+        ///     Apply censors to a JSON string.
+        /// </summary>
+        /// <param name="data">JSON string to apply censors to.</param>
+        /// <param name="censorText">Test to use to replace censored elements.</param>
+        /// <param name="elementsToCensors">List of elements to censor.</param>
+        /// <returns>A censored JSON string.</returns>
+        public static string CensorJsonData(string data, string censorText, IReadOnlyCollection<CensorElement> elementsToCensors)
         {
             try
             {
-                var jsonDictionary = JsonSerialization.ConvertJsonToObject<Dictionary<string, object>>(body);
+                var jsonDictionary = JsonSerialization.ConvertJsonToObject<Dictionary<string, object>>(data);
                 var censoredJsonDictionary = ApplyDataCensors(jsonDictionary, censorText, elementsToCensors);
-                return censoredJsonDictionary == null ? body : JsonSerialization.ConvertObjectToJson(censoredJsonDictionary);
+                return censoredJsonDictionary == null ? data : JsonSerialization.ConvertObjectToJson(censoredJsonDictionary);
             }
             catch (Exception)
             {
                 // body is not a JSON dictionary
                 try
                 {
-                    var jsonList = JsonSerialization.ConvertJsonToObject<List<object>>(body);
+                    var jsonList = JsonSerialization.ConvertJsonToObject<List<object>>(data);
                     var censoredJsonList = ApplyDataCensors(jsonList, censorText, elementsToCensors);
-                    return censoredJsonList == null ? body : JsonSerialization.ConvertObjectToJson(censoredJsonList);
+                    return censoredJsonList == null ? data : JsonSerialization.ConvertObjectToJson(censoredJsonList);
                 }
                 catch
                 {
                     // short circuit if body is not a JSON dictionary or JSON list
-                    return body;
+                    return data;
                 }
             }
         }
 
-        public static string CensorXmlData(string body, string censorText, IReadOnlyCollection<CensorElement> elementsToCensors)
+        /// <summary>
+        ///     Apply censors to an XML string.
+        /// </summary>
+        /// <param name="data">XML string to apply censors to.</param>
+        /// <param name="censorText">Test to use to replace censored elements.</param>
+        /// <param name="elementsToCensors">List of elements to censor.</param>
+        /// <returns>A censored XML string.</returns>
+        public static string CensorXmlData(string data, string censorText, IReadOnlyCollection<CensorElement> elementsToCensors)
         {
             try
             {
-                var xmlDictionary = XmlSerialization.ConvertXmlToObject<Dictionary<string, object>>(body);
+                var xmlDictionary = XmlSerialization.ConvertXmlToObject<Dictionary<string, object>>(data);
                 var censoredXmlDictionary = ApplyDataCensors(xmlDictionary, censorText, elementsToCensors);
-                return censoredXmlDictionary == null ? body : XmlSerialization.ConvertObjectToXml(censoredXmlDictionary);
+                return censoredXmlDictionary == null ? data : XmlSerialization.ConvertObjectToXml(censoredXmlDictionary);
             }
             catch (Exception)
             {
                 // body is not an XML dictionary
                 try
                 {
-                    var xmlList = XmlSerialization.ConvertXmlToObject<List<object>>(body);
+                    var xmlList = XmlSerialization.ConvertXmlToObject<List<object>>(data);
                     var censoredXmlList = ApplyDataCensors(xmlList, censorText, elementsToCensors);
-                    return censoredXmlList == null ? body : XmlSerialization.ConvertObjectToXml(censoredXmlList);
+                    return censoredXmlList == null ? data : XmlSerialization.ConvertObjectToXml(censoredXmlList);
                 }
                 catch
                 {
                     // short circuit if body is not a XML dictionary or XML list
-                    return body;
+                    return data;
                 }
             }
         }
 
+        /// <summary>
+        ///     Apply censors to a list of elements.
+        /// </summary>
+        /// <param name="list">List of elements to apply censors to.</param>
+        /// <param name="censorText">Test to use to replace censored elements.</param>
+        /// <param name="elementsToCensors">List of elements to censor.</param>
+        /// <returns>A censored list of elements.</returns>
         private static List<object> ApplyDataCensors(List<object> list, string censorText, IReadOnlyCollection<CensorElement> elementsToCensors)
         {
             if (list.Count == 0)
@@ -322,6 +343,13 @@ namespace EasyVCR
             return censoredList;
         }
 
+        /// <summary>
+        ///     Apply censors to a dictionary of elements.
+        /// </summary>
+        /// <param name="dictionary">Dictionary of elements to apply censors to.</param>
+        /// <param name="censorText">Test to use to replace censored elements.</param>
+        /// <param name="elementsToCensors">List of elements to censor.</param>
+        /// <returns>A censored dictionary of elements.</returns>
         private static Dictionary<string, object> ApplyDataCensors(Dictionary<string, object> dictionary, string censorText, IReadOnlyCollection<CensorElement> elementsToCensors)
         {
             if (dictionary.Count == 0)
@@ -387,14 +415,25 @@ namespace EasyVCR
             return censoredBodyDictionary;
         }
 
+        /// <summary>
+        ///     Check if a JSON element should be censored.
+        /// </summary>
+        /// <param name="foundKey">The key of the JSON element to evaluate.</param>
+        /// <param name="elementsToCensor">A list of elements to censor.</param>
+        /// <returns>True if the JSON value should be censored, false otherwise.</returns>
         private static bool KeyShouldBeCensored(string foundKey, IReadOnlyCollection<CensorElement> elementsToCensor)
         {
             return elementsToCensor.Count != 0 && elementsToCensor.Any(element => element.Matches(foundKey));
         }
 
-        private static string ToQueryString(NameValueCollection collection)
+        /// <summary>
+        ///     Convert a collection of query parameter pairs to a query string.
+        /// </summary>
+        /// <param name="queryParamCollection">Collection of key-value pairs.</param>
+        /// <returns>A formatted URL query string.</returns>
+        private static string ToQueryString(NameValueCollection queryParamCollection)
         {
-            return string.Join("&", collection.AllKeys.Select(key => $"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(collection.Get(key))}").ToArray());
+            return string.Join("&", queryParamCollection.AllKeys.Select(key => $"{HttpUtility.UrlEncode(key)}={HttpUtility.UrlEncode(queryParamCollection.Get(key))}").ToArray());
         }
     }
 }

--- a/EasyVCR/InternalUtilities/DefaultInteractionConverter.cs
+++ b/EasyVCR/InternalUtilities/DefaultInteractionConverter.cs
@@ -46,12 +46,12 @@ namespace EasyVCR.InternalUtilities
             var request = new Request
             {
                 Method = httpRequestMessage.Method.ToString(),
-                Uri = censors.CensorQueryParameters(httpRequestMessage.RequestUri?.ToString()),
-                RequestHeaders = censors.CensorHeaders(ToHeaders(httpRequestMessage.Headers)),
-                ContentHeaders = censors.CensorHeaders(ToContentHeaders(httpRequestMessage.Content)),
+                Uri = censors.ApplyQueryParametersCensors(httpRequestMessage.RequestUri?.ToString()),
+                RequestHeaders = censors.ApplyHeaderCensors(ToHeaders(httpRequestMessage.Headers)),
+                ContentHeaders = censors.ApplyHeaderCensors(ToContentHeaders(httpRequestMessage.Content)),
                 BodyContentType = ContentTypeExtensions.DetermineContentType(requestBody)
             };
-            request.Body = censors.CensorBodyParameters(requestBody, request.BodyContentType);
+            request.Body = censors.ApplyBodyParametersCensors(requestBody, request.BodyContentType);
             return request;
         }
 
@@ -71,12 +71,12 @@ namespace EasyVCR.InternalUtilities
                     Code = httpResponseMessage.StatusCode,
                     Message = httpResponseMessage.ReasonPhrase
                 },
-                ResponseHeaders = censors.CensorHeaders(ToHeaders(httpResponseMessage.Headers)),
-                ContentHeaders = censors.CensorHeaders(ToContentHeaders(httpResponseMessage.Content)),
+                ResponseHeaders = censors.ApplyHeaderCensors(ToHeaders(httpResponseMessage.Headers)),
+                ContentHeaders = censors.ApplyHeaderCensors(ToContentHeaders(httpResponseMessage.Content)),
                 BodyContentType = ContentTypeExtensions.DetermineContentType(responseBody),
                 HttpVersion = httpResponseMessage.Version
             };
-            response.Body = censors.CensorBodyParameters(responseBody, response.BodyContentType);
+            response.Body = censors.ApplyBodyParametersCensors(responseBody, response.BodyContentType);
             return response;
         }
 

--- a/EasyVCR/InternalUtilities/JSON/Serialization.cs
+++ b/EasyVCR/InternalUtilities/JSON/Serialization.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Dynamic;
 using System.Xml.Linq;
 using EasyVCR.Interfaces;
@@ -110,14 +111,22 @@ namespace EasyVCR.InternalUtilities.JSON
         ///     Normalize a JSON string to remove CRLF and other whitespace.
         /// </summary>
         /// <param name="json">JSON string to normalize.</param>
+        /// <param name="removeElements">List of elements to remove from the JSON string.</param>
         /// <returns>Normalized JSON string.</returns>
-        internal static string? NormalizeJson(string json)
+        internal static string? NormalizeJson(string json, List<CensorElement>? removeElements = null)
         {
             if (string.IsNullOrWhiteSpace(json))
             {
                 return null;
             }
 
+            // need to use censors to remove elements from the JSON string
+            if (removeElements != null)
+            {
+                return Censors.CensorJsonData(json, "FILTERED", removeElements);
+            }
+
+            // don't need to remove elements
             object obj = ConvertJsonToObject(json);
             return ConvertObjectToJson(obj);
         }

--- a/EasyVCR/MatchRules.cs
+++ b/EasyVCR/MatchRules.cs
@@ -51,8 +51,9 @@ namespace EasyVCR
         /// <summary>
         ///     Add a rule to compare the bodies of the requests.
         /// </summary>
+        /// <param name="ignoredElements">List of body elements to ignore when matching by body.</param>
         /// <returns>The same MatchRules object.</returns>
-        public MatchRules ByBody()
+        public MatchRules ByBody(List<CensorElement>? ignoredElements = null)
         {
             By((received, recorded) =>
             {
@@ -64,8 +65,8 @@ namespace EasyVCR
                     // one has a null body, so they don't match
                     return false;
 
-                string? receivedBody = JsonSerialization.NormalizeJson(received.Body);
-                string? recordedBody = JsonSerialization.NormalizeJson(recorded.Body);
+                var receivedBody = JsonSerialization.NormalizeJson(received.Body, ignoredElements);
+                var recordedBody = JsonSerialization.NormalizeJson(recorded.Body, ignoredElements);
 
                 if (receivedBody == null && recordedBody == null)
                     // both have empty string bodies, so they match


### PR DESCRIPTION
Same changes as the Java version: https://github.com/EasyPost/easyvcr-java/pull/6

- Reuse censoring code to effectively ignore (normalize) specific elements in the bodies when matching by request body.
- Made a number of censoring methods static for normalization purposes, with instance-based overloads for normal censoring process.
- Side-effect improvement: Censored header/query/body elements can now be case-sensitive on a per-element basis.