### PR TITLE
Expiration controls and custom logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 - New feature: Set expiration time for interactions (how long since it was recorded should an interaction be considered valid)
   - Can determine what to do if a matching interaction is considered invalid:
     - Warn the user, but proceed with the interaction
-    - Address the expiration (throw an exception if in `Replay` mode, automatically re-record interaction in `Auto` mode)
+    - Throw an exception
+    - Automatically re-record (cannot be used in `Replay` mode)
+- New feature: Pass in a custom ILogger instance to EasyVCR to funnel log messages into your own logging setup (fallback: logs to console)
 
 ## v0.4.0 (2022-06-13)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Next Release
+- New feature: Set expiration time for interactions (how long since it was recorded should an interaction be considered valid)
+  - Can determine what to do if a matching interaction is considered invalid:
+    - Warn the user, but proceed with the interaction
+    - Address the expiration (throw an exception if in `Replay` mode, automatically re-record interaction in `Auto` mode)
+
 ## v0.4.0 (2022-06-13)
 
 - Improvements to censoring

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -201,12 +201,20 @@ namespace EasyVCR.Tests
             var advancedSettings = new AdvancedSettings
             {
                 ValidTimeFrame = TimeFrame.Never,
-                WhenExpired = ExpirationActions.RecordAgain // throw exception when in replay mode
+                WhenExpired = ExpirationActions.ThrowException // throw exception when in replay mode
             };
             Task.Delay(TimeSpan.FromSeconds(1)).Wait(); // Allow 1 second to lapse to ensure recording is now "expired"
             client = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
             fakeDataService = new FakeJsonDataService(client);
             await Assert.ThrowsExceptionAsync<VCRException>(async () => await fakeDataService.GetExchangeRatesRawResponse());
+
+            // replay cassette with bad expiration rules, should throw an exception because settings are bad
+            advancedSettings = new AdvancedSettings
+            {
+                ValidTimeFrame = TimeFrame.Never,
+                WhenExpired = ExpirationActions.RecordAgain // invalid settings for replay mode, should throw exception
+            };
+            await Assert.ThrowsExceptionAsync<VCRException>(() => Task.FromResult(HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings)));
         }
 
         [TestMethod]

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -189,7 +189,7 @@ namespace EasyVCR.Tests
             // record cassette first
             var client = HttpClients.NewHttpClient(cassette, Mode.Record);
             var fakeDataService = new FakeJsonDataService(client);
-            var _ = await fakeDataService.GetExchangeRatesRawResponse();
+            await fakeDataService.GetExchangeRatesRawResponse();
 
             // replay cassette with default expiration rules, should find a match
             client = HttpClients.NewHttpClient(cassette, Mode.Replay);

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -201,7 +201,7 @@ namespace EasyVCR.Tests
             var advancedSettings = new AdvancedSettings
             {
                 ValidTimeFrame = TimeFrame.Never,
-                WhenExpired = ExpirationActions.Address // throw exception when in replay mode
+                WhenExpired = ExpirationActions.RecordAgain // throw exception when in replay mode
             };
             Task.Delay(TimeSpan.FromSeconds(1)).Wait(); // Allow 1 second to lapse to ensure recording is now "expired"
             client = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -177,6 +178,35 @@ namespace EasyVCR.Tests
             Assert.IsNotNull(summary);
             Assert.IsNotNull(summary.Rates);
             Assert.IsTrue(cassette.NumInteractions > 0); // Make sure cassette is not empty
+        }
+
+        [TestMethod]
+        public async Task TestExpirationSettings()
+        {
+            var cassette = TestUtils.GetCassette("test_expiration_settings");
+            cassette.Erase(); // Erase cassette before recording
+
+            // record cassette first
+            var client = HttpClients.NewHttpClient(cassette, Mode.Record);
+            var fakeDataService = new FakeJsonDataService(client);
+            var _ = await fakeDataService.GetExchangeRatesRawResponse();
+
+            // replay cassette with default expiration rules, should find a match
+            client = HttpClients.NewHttpClient(cassette, Mode.Replay);
+            fakeDataService = new FakeJsonDataService(client);
+            var response = await fakeDataService.GetExchangeRatesRawResponse();
+            Assert.IsNotNull(response);
+
+            // replay cassette with custom expiration rules, should not find a match because recording is expired (throw exception)
+            var advancedSettings = new AdvancedSettings
+            {
+                ValidTimeFrame = TimeFrame.Never,
+                WhenExpired = ExpirationActions.Address // throw exception when in replay mode
+            };
+            Task.Delay(TimeSpan.FromSeconds(1)).Wait(); // Allow 1 second to lapse to ensure recording is now "expired"
+            client = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
+            fakeDataService = new FakeJsonDataService(client);
+            await Assert.ThrowsExceptionAsync<VCRException>(async () => await fakeDataService.GetExchangeRatesRawResponse());
         }
 
         [TestMethod]

--- a/EasyVCR/AdvancedSettings.cs
+++ b/EasyVCR/AdvancedSettings.cs
@@ -36,6 +36,16 @@ namespace EasyVCR
         public bool SimulateDelay = false;
 
         /// <summary>
+        ///     How long should a given cassette entry be considered valid.
+        /// </summary>
+        public TimeFrame? ValidTimeFrame = TimeFrame.Forever;
+
+        /// <summary>
+        ///     What should happen if a given cassette entry is expired.
+        /// </summary>
+        public ExpirationActions WhenExpired = ExpirationActions.Warn;
+
+        /// <summary>
         ///     Retrieve the manual delay as a TimeSpan.
         /// </summary>
         internal TimeSpan? ManualDelayTimeSpan => ManualDelay >= 0 ? TimeSpan.FromMilliseconds(ManualDelay) : TimeSpan.Zero;

--- a/EasyVCR/AdvancedSettings.cs
+++ b/EasyVCR/AdvancedSettings.cs
@@ -1,6 +1,9 @@
 using System;
 using EasyVCR.Interfaces;
 using EasyVCR.InternalUtilities;
+using Microsoft.Extensions.Logging;
+
+// ReSharper disable FieldCanBeMadeReadOnly.Global
 
 namespace EasyVCR
 {
@@ -20,6 +23,11 @@ namespace EasyVCR
         /// </summary>
         // ReSharper disable once FieldCanBeMadeReadOnly.Global
         public IInteractionConverter? InteractionConverter = new DefaultInteractionConverter();
+
+        /// <summary>
+        ///     Tell EasyVCR to use a custom <see cref="ILogger"/> logger. Will log to console otherwise.
+        /// </summary>
+        public ILogger? Logger = null;
 
         /// <summary>
         ///     Simulate a delay in milliseconds for the request.

--- a/EasyVCR/EasyVCR.csproj
+++ b/EasyVCR/EasyVCR.csproj
@@ -49,6 +49,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0"/>
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 

--- a/EasyVCR/ExpirationActions.cs
+++ b/EasyVCR/ExpirationActions.cs
@@ -1,0 +1,16 @@
+namespace EasyVCR
+{
+    public enum ExpirationActions
+    {
+        /// <summary>
+        ///     Warn that the recorded interaction is expired, but proceed as normal.
+        /// </summary>
+        Warn,
+        /// <summary>
+        ///     Address the expiration.
+        ///     In replay mode, this will throw an exception.
+        ///     In auto mode, this will automatically re-record the interaction.
+        /// </summary>
+        Address
+    }
+}

--- a/EasyVCR/ExpirationActions.cs
+++ b/EasyVCR/ExpirationActions.cs
@@ -1,5 +1,8 @@
 namespace EasyVCR
 {
+    /// <summary>
+    ///     Enums representing different actions to take when a recording is expired.
+    /// </summary>
     public enum ExpirationActions
     {
         /// <summary>

--- a/EasyVCR/ExpirationActions.cs
+++ b/EasyVCR/ExpirationActions.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace EasyVCR
 {
     /// <summary>
@@ -10,10 +12,23 @@ namespace EasyVCR
         /// </summary>
         Warn,
         /// <summary>
-        ///     Address the expiration.
-        ///     In replay mode, this will throw an exception.
-        ///     In auto mode, this will automatically re-record the interaction.
+        ///     Throw an exception that the recorded interaction is expired.
         /// </summary>
-        Address
+        ThrowException,
+        /// <summary>
+        ///     Automatically re-record the recorded interaction. This cannot be used with <see cref="Mode.Replay" />.
+        /// </summary>
+        RecordAgain
+    }
+
+    internal static class ExpirationActionExtensions
+    {
+        internal static void CheckCompatibleSettings(ExpirationActions action, Mode mode)
+        {
+            if (action == ExpirationActions.RecordAgain && mode == Mode.Replay)
+            {
+                throw new VCRException("Cannot use the RecordAgain expiration action in combination with Replay mode.");
+            }
+        }
     }
 }

--- a/EasyVCR/Handlers/VCRHandler.cs
+++ b/EasyVCR/Handlers/VCRHandler.cs
@@ -20,6 +20,7 @@ namespace EasyVCR.Handlers
         private readonly Censors _censors;
         private readonly TimeSpan? _delay;
         private readonly IInteractionConverter _interactionConverter;
+        private readonly ConsoleFallbackLogger _logger;
         private readonly MatchRules _matchRules;
         private readonly Mode _mode;
         private readonly bool _useOriginalDelay;
@@ -38,7 +39,6 @@ namespace EasyVCR.Handlers
             InnerHandler = innerHandler;
             _cassette = cassette;
             _mode = mode;
-
             _censors = advancedSettings?.Censors ?? new Censors();
             _interactionConverter = advancedSettings?.InteractionConverter ?? new DefaultInteractionConverter();
             _matchRules = advancedSettings?.MatchRules ?? new MatchRules();
@@ -46,6 +46,10 @@ namespace EasyVCR.Handlers
             _delay = advancedSettings?.ManualDelayTimeSpan ?? TimeSpan.Zero;
             _validTimeFrame = advancedSettings?.ValidTimeFrame ?? TimeFrame.Forever;
             _whenExpired = advancedSettings?.WhenExpired ?? ExpirationActions.Warn;
+            _logger = new ConsoleFallbackLogger(advancedSettings?.Logger, "EasyVCR");
+
+            // Will throw an exception if an invalid settings combination is provided.
+            ExpirationActionExtensions.CheckCompatibleSettings(_whenExpired, _mode);
         }
 
         /// <summary>
@@ -79,11 +83,14 @@ namespace EasyVCR.Handlers
                             case ExpirationActions.Warn:
                                 // just throw a warning
                                 // will still simulate delay below
-                                Console.WriteLine($"WARNING: Matching interaction is expired.");
+                                _logger.Warning("Matching interaction is expired.");
                                 break;
-                            case ExpirationActions.Address:
+                            case ExpirationActions.ThrowException:
                                 // throw an exception and exit this function
                                 throw new VCRException($"Matching interaction is expired.");
+                            case ExpirationActions.RecordAgain:
+                                // we should never get here, the settings check should catch this during construction
+                                throw new VCRException("Cannot re-record an expired interaction in Replay mode.");
                             default:
                                 // we should never get here
                                 throw new ArgumentOutOfRangeException();
@@ -108,9 +115,12 @@ namespace EasyVCR.Handlers
                                 case ExpirationActions.Warn:
                                     // just throw a warning
                                     // will still simulate delay below
-                                    Console.WriteLine($"WARNING: Matching interaction is expired.");
+                                    _logger.Warning("Matching interaction is expired.");
                                     break;
-                                case ExpirationActions.Address:
+                                case ExpirationActions.ThrowException:
+                                    // throw an exception and exit this function
+                                    throw new VCRException($"Matching interaction is expired.");
+                                case ExpirationActions.RecordAgain:
                                     //  re-record over expired interaction
                                     // this will not execute the simulated delay, but since it's making a live request, a real delay will happen.
                                     stopwatch.Start();

--- a/EasyVCR/InternalUtilities/Logging.cs
+++ b/EasyVCR/InternalUtilities/Logging.cs
@@ -1,0 +1,76 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace EasyVCR.InternalUtilities
+{
+    /// <summary>
+    ///     A logger that, if there's no proper logger, writes to the console instead.
+    /// </summary>
+    internal class ConsoleFallbackLogger
+    {
+        private readonly ILogger? _innerLogger;
+
+        private readonly string _name;
+
+
+        /// <summary>
+        ///     Constructor.
+        /// </summary>
+        /// <param name="logger"><see cref="ILogger" /> logger to optionally use internally.</param>
+        /// <param name="name">Name of </param>
+        internal ConsoleFallbackLogger(ILogger? logger, string name)
+        {
+            _name = name;
+            _innerLogger = logger;
+        }
+
+        /// <summary>
+        ///     Logs an error message to the logger or console.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Arguments for message formatting.</param>
+        internal void Error(string message, params object?[] args)
+        {
+            Log(
+                (msg, a) => _innerLogger?.LogError(msg, a),
+                (msg, a) => Console.Error.WriteLine(msg, a),
+                message,
+                args);
+        }
+
+        /// <summary>
+        ///     Logs a warning message to the logger or console.
+        /// </summary>
+        /// <param name="message">Message to log.</param>
+        /// <param name="args">Arguments for message formatting.</param>
+        internal void Warning(string message, params object?[] args)
+        {
+            Log(
+                (msg, a) => _innerLogger?.LogWarning(msg, a),
+                Console.WriteLine,
+                message,
+                args);
+        }
+
+        /// <summary>
+        ///     Log a message using the logFunc if there's a logger, otherwise using the fallback action.
+        /// </summary>
+        /// <param name="logFunc">Function to execute if a logger exists.</param>
+        /// <param name="fallbackAction">Function to execute if a logger does not exist.</param>
+        /// <param name="message">Message to be passed to function.</param>
+        /// <param name="args">Message arguments to be passed to function.</param>
+        private void Log(Action<string, object?[]> logFunc, Action<string, object?[]> fallbackAction, string message, params object?[] args)
+        {
+            if (_innerLogger != null)
+            {
+                logFunc(_name, args);
+            }
+            else
+            {
+                fallbackAction(MakeMessage(message), args);
+            }
+        }
+
+        private string MakeMessage(string message) => $"{_name}: {message}";
+    }
+}

--- a/EasyVCR/TimeFrame.cs
+++ b/EasyVCR/TimeFrame.cs
@@ -76,7 +76,7 @@ namespace EasyVCR
 
 
         // @formatter:off
-        
+
         /// <summary>
         ///     Get a TimeFrame that represents "never".
         /// </summary>
@@ -84,7 +84,7 @@ namespace EasyVCR
         {
             CommonTimeFrame = CommonTimeFrames.Never
         };
-        
+
         /// <summary>
         ///     Get a TimeFrame that represents "forever".
         /// </summary>
@@ -124,7 +124,7 @@ namespace EasyVCR
         {
             Days = 182
         };
-        
+
         /// <summary>
         ///     Get a TimeFrame that represents 12 months.
         /// </summary>
@@ -132,7 +132,7 @@ namespace EasyVCR
         {
             Days = 365
         };
-        
+
         // @formatter:on
     }
 }

--- a/EasyVCR/TimeFrame.cs
+++ b/EasyVCR/TimeFrame.cs
@@ -42,62 +42,6 @@ namespace EasyVCR
         private CommonTimeFrames? CommonTimeFrame { get; set; }
 
         /// <summary>
-        ///     Get a TimeFrame that represents "forever".
-        /// </summary>
-        public static TimeFrame Forever => new TimeFrame
-        {
-            CommonTimeFrame = CommonTimeFrames.Forever
-        };
-
-        /// <summary>
-        ///     Get a TimeFrame that represents 1 month.
-        /// </summary>
-        public static TimeFrame Months1 => new TimeFrame
-        {
-            Days = 30
-        };
-
-        /// <summary>
-        ///     Get a TimeFrame that represents 12 months.
-        /// </summary>
-        public static TimeFrame Months12 => new TimeFrame
-        {
-            Days = 365
-        };
-
-        /// <summary>
-        ///     Get a TimeFrame that represents 2 months.
-        /// </summary>
-        public static TimeFrame Months2 => new TimeFrame
-        {
-            Days = 61
-        };
-
-        /// <summary>
-        ///     Get a TimeFrame that represents 3 months.
-        /// </summary>
-        public static TimeFrame Months3 => new TimeFrame
-        {
-            Days = 91
-        };
-
-        /// <summary>
-        ///     Get a TimeFrame that represents 6 months.
-        /// </summary>
-        public static TimeFrame Months6 => new TimeFrame
-        {
-            Days = 182
-        };
-
-        /// <summary>
-        ///     Get a TimeFrame that represents "never".
-        /// </summary>
-        public static TimeFrame Never => new TimeFrame
-        {
-            CommonTimeFrame = CommonTimeFrames.Never
-        };
-
-        /// <summary>
         ///     Constructor for a TimeFrame object.
         /// </summary>
         public TimeFrame()
@@ -129,5 +73,66 @@ namespace EasyVCR
                 var _ => fromTime.AddDays(Days).AddHours(Hours).AddMinutes(Minutes).AddSeconds(Seconds)
             };
         }
+
+
+        // @formatter:off
+        
+        /// <summary>
+        ///     Get a TimeFrame that represents "never".
+        /// </summary>
+        public static TimeFrame Never => new TimeFrame
+        {
+            CommonTimeFrame = CommonTimeFrames.Never
+        };
+        
+        /// <summary>
+        ///     Get a TimeFrame that represents "forever".
+        /// </summary>
+        public static TimeFrame Forever => new TimeFrame
+        {
+            CommonTimeFrame = CommonTimeFrames.Forever
+        };
+
+        /// <summary>
+        ///     Get a TimeFrame that represents 1 month.
+        /// </summary>
+        public static TimeFrame Months1 => new TimeFrame
+        {
+            Days = 30
+        };
+
+        /// <summary>
+        ///     Get a TimeFrame that represents 2 months.
+        /// </summary>
+        public static TimeFrame Months2 => new TimeFrame
+        {
+            Days = 61
+        };
+
+        /// <summary>
+        ///     Get a TimeFrame that represents 3 months.
+        /// </summary>
+        public static TimeFrame Months3 => new TimeFrame
+        {
+            Days = 91
+        };
+
+        /// <summary>
+        ///     Get a TimeFrame that represents 6 months.
+        /// </summary>
+        public static TimeFrame Months6 => new TimeFrame
+        {
+            Days = 182
+        };
+        
+        /// <summary>
+        ///     Get a TimeFrame that represents 12 months.
+        /// </summary>
+        public static TimeFrame Months12 => new TimeFrame
+        {
+            Days = 365
+        };
+        
+        // @formatter:on
     }
 }

--- a/EasyVCR/TimeFrame.cs
+++ b/EasyVCR/TimeFrame.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace EasyVCR
+{
+    internal enum CommonTimeFrames
+    {
+        Never,
+        Forever,
+    }
+
+    public class TimeFrame
+    {
+        public int Days { get; set; }
+
+        public int Hours { get; set; }
+
+        public int Minutes { get; set; }
+
+        public int Seconds { get; set; }
+
+        internal CommonTimeFrames? CommonTimeFrame { get; set; }
+
+        public static TimeFrame Forever => new TimeFrame
+        {
+            CommonTimeFrame = CommonTimeFrames.Forever
+        };
+
+        public static TimeFrame Never => new TimeFrame
+        {
+            CommonTimeFrame = CommonTimeFrames.Never
+        };
+
+        public TimeFrame()
+        {
+        }
+
+        public bool HasLapsed(DateTimeOffset fromTime)
+        {
+            var startTimePlusFrame = TimePlusFrame(fromTime.DateTime);
+            return startTimePlusFrame < DateTime.Now;
+        }
+
+        private DateTime TimePlusFrame(DateTime fromTime)
+        {
+            return CommonTimeFrame switch
+            {
+                CommonTimeFrames.Forever => DateTime.MaxValue, // will always be in the future
+                CommonTimeFrames.Never => DateTime.MinValue, // will always been in the past
+                var _ => fromTime.AddDays(Days).AddHours(Hours).AddMinutes(Minutes).AddSeconds(Seconds)
+            };
+        }
+    }
+}

--- a/EasyVCR/TimeFrame.cs
+++ b/EasyVCR/TimeFrame.cs
@@ -19,22 +19,22 @@ namespace EasyVCR
         /// <summary>
         ///     Number of days for this time frame.
         /// </summary>
-        public int Days { get; set; }
+        public int Days { get; set; } = 0;
 
         /// <summary>
         ///     Number of hours for this time frame.
         /// </summary>
-        public int Hours { get; set; }
+        public int Hours { get; set; } = 0;
 
         /// <summary>
         ///     Number of minutes for this time frame.
         /// </summary>
-        public int Minutes { get; set; }
+        public int Minutes { get; set; } = 0;
 
         /// <summary>
         ///     Number of seconds for this time frame.
         /// </summary>
-        public int Seconds { get; set; }
+        public int Seconds { get; set; } = 0;
 
         /// <summary>
         ///     If this time frame is a common time frame.
@@ -47,6 +47,46 @@ namespace EasyVCR
         public static TimeFrame Forever => new TimeFrame
         {
             CommonTimeFrame = CommonTimeFrames.Forever
+        };
+
+        /// <summary>
+        ///     Get a TimeFrame that represents 1 month.
+        /// </summary>
+        public static TimeFrame Months1 => new TimeFrame
+        {
+            Days = 30
+        };
+
+        /// <summary>
+        ///     Get a TimeFrame that represents 12 months.
+        /// </summary>
+        public static TimeFrame Months12 => new TimeFrame
+        {
+            Days = 365
+        };
+
+        /// <summary>
+        ///     Get a TimeFrame that represents 2 months.
+        /// </summary>
+        public static TimeFrame Months2 => new TimeFrame
+        {
+            Days = 61
+        };
+
+        /// <summary>
+        ///     Get a TimeFrame that represents 3 months.
+        /// </summary>
+        public static TimeFrame Months3 => new TimeFrame
+        {
+            Days = 91
+        };
+
+        /// <summary>
+        ///     Get a TimeFrame that represents 6 months.
+        /// </summary>
+        public static TimeFrame Months6 => new TimeFrame
+        {
+            Days = 182
         };
 
         /// <summary>

--- a/EasyVCR/TimeFrame.cs
+++ b/EasyVCR/TimeFrame.cs
@@ -2,44 +2,84 @@ using System;
 
 namespace EasyVCR
 {
-    internal enum CommonTimeFrames
-    {
-        Never,
-        Forever,
-    }
-
+    /// <summary>
+    ///     TimeFrame used to store a number of days, hours, minutes and seconds.
+    /// </summary>
     public class TimeFrame
     {
+        /// <summary>
+        ///     Enums for common time frames.
+        /// </summary>
+        private enum CommonTimeFrames
+        {
+            Never,
+            Forever,
+        }
+
+        /// <summary>
+        ///     Number of days for this time frame.
+        /// </summary>
         public int Days { get; set; }
 
+        /// <summary>
+        ///     Number of hours for this time frame.
+        /// </summary>
         public int Hours { get; set; }
 
+        /// <summary>
+        ///     Number of minutes for this time frame.
+        /// </summary>
         public int Minutes { get; set; }
 
+        /// <summary>
+        ///     Number of seconds for this time frame.
+        /// </summary>
         public int Seconds { get; set; }
 
-        internal CommonTimeFrames? CommonTimeFrame { get; set; }
+        /// <summary>
+        ///     If this time frame is a common time frame.
+        /// </summary>
+        private CommonTimeFrames? CommonTimeFrame { get; set; }
 
+        /// <summary>
+        ///     Get a TimeFrame that represents "forever".
+        /// </summary>
         public static TimeFrame Forever => new TimeFrame
         {
             CommonTimeFrame = CommonTimeFrames.Forever
         };
 
+        /// <summary>
+        ///     Get a TimeFrame that represents "never".
+        /// </summary>
         public static TimeFrame Never => new TimeFrame
         {
             CommonTimeFrame = CommonTimeFrames.Never
         };
 
+        /// <summary>
+        ///     Constructor for a TimeFrame object.
+        /// </summary>
         public TimeFrame()
         {
         }
 
+        /// <summary>
+        ///     Check if this time frame has lapsed from the given time.
+        /// </summary>
+        /// <param name="fromTime">Time to add time frame to.</param>
+        /// <returns>Whether this time frame has lapsed.</returns>
         public bool HasLapsed(DateTimeOffset fromTime)
         {
             var startTimePlusFrame = TimePlusFrame(fromTime.DateTime);
             return startTimePlusFrame < DateTime.Now;
         }
 
+        /// <summary>
+        ///     Get the provided time plus the time frame.
+        /// </summary>
+        /// <param name="fromTime">Starting time.</param>
+        /// <returns>Starting time plus this time frame.</returns>
         private DateTime TimePlusFrame(DateTime fromTime)
         {
             return CommonTimeFrame switch

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ var advancedOptions = new AdvancedOptions()
     ValidTimeFrame = new TimeFrame() {  // Any matching request is considered expired if it was recorded more than 30 days ago
         Days = 30,
     },
-    WhenExpired = ExpirationActions.Address // Throw exception if in replay mode, automatically re-record if in auto mode
+    WhenExpired = ExpirationActions.ThrowException // Throw exception if the recording is expired
 };
 
 var httpClient = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);

--- a/README.md
+++ b/README.md
@@ -101,6 +101,27 @@ var advancedOptions = new AdvancedOptions()
 var httpClient = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
 ```
 
+### Expiration
+
+Set expiration dates for recorded requests, and decide what to do with expired recordings.
+
+**Default**: *No expiration*
+
+```csharp
+using EasyVCR;
+
+var cassette = new Cassette("path/to/cassettes", "my_cassette");
+var advancedOptions = new AdvancedOptions()
+{
+    ValidTimeFrame = new TimeFrame() {  // Any matching request is considered expired if it was recorded more than 30 days ago
+        Days = 30,
+    },
+    WhenExpired = ExpirationActions.Address // Throw exception if in replay mode, automatically re-record if in auto mode
+};
+
+var httpClient = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
+```
+
 ### Matching
 
 Customize how a recorded request is determined to be a match to the current request.

--- a/README.md
+++ b/README.md
@@ -158,6 +158,43 @@ var cassette = new Cassette("path/to/cassettes", "my_cassette", order);
 var httpClient = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
 ```
 
+### Delay
+
+Simulate a delay when replaying a recorded request, either using a specified delay or the original request duration.
+
+**Default**: *No delay*
+
+```csharp
+using EasyVCR;
+
+var cassette = new Cassette("path/to/cassettes", "my_cassette");
+var advancedOptions = new AdvancedOptions()
+{
+    SimulateDelay = true, // Simulate a delay of the original request duration when replaying (overrides ManualDelay)
+    ManualDelay = 1000 // Simulate a delay of 1000 milliseconds when replaying
+};
+
+var httpClient = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
+```
+
+### Logging
+
+Have EasyVCR integrate with your custom logger to log warnings and errors.
+
+**Default**: *Logs to console*
+
+```csharp
+using EasyVCR;
+
+var cassette = new Cassette("path/to/cassettes", "my_cassette");
+var advancedOptions = new AdvancedOptions()
+{
+    Logger = new MyCustomLogger(), // Have EasyVCR use your custom logger when making log entries
+};
+
+var httpClient = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
+```
+
 ### HttpClient Conversion
 
 Override how HttpClient request and response objects are converted into `EasyVCR` request and response objects, and vice


### PR DESCRIPTION
Set expiration time for interactions (how long since it was recorded should an interaction be considered valid)
  - Can determine what to do if a matching interaction is considered invalid:
    - Warn the user, but proceed with the interaction
    - Address the expiration (throw an exception if in `Replay` mode, automatically re-record interaction in `Auto` mode)

Users can pass in a logger to EasyVCR (will be used to log warnings for expiration; otherwise, log to console)