### PR TITLE
Re-enable unit test

### DIFF
--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -101,7 +101,6 @@ namespace EasyVCR.Tests
         }
 
         [TestMethod]
-        [Ignore] // TODO: fix this test
         public async Task TestDelay()
         {
             var cassette = TestUtils.GetCassette("test_delay");

--- a/Makefile
+++ b/Makefile
@@ -91,9 +91,13 @@ scan:
 	dotnet tool run security-scan --verbose --no-banner --ignore-msbuild-errors EasyVCR.sln
     # "--ignore-msbuild-errors" needed since MSBuild does not like F#: https://github.com/security-code-scan/security-code-scan/issues/235
 
-## setup - Install required .NET versions and tools (Windows only)
-setup:
+## setup-win - Install required .NET versions and tools (Windows only)
+setup-win:
 	scripts\setup.bat
+
+## setup-unix - Install required .NET versions and tools (Unix only)
+setup-unix:
+	bash scripts/setup.sh
 
 ## sign - Sign all generated DLLs and NuGet packages with the provided certificate (Windows only)
 # @parameters:
@@ -118,4 +122,4 @@ test-fw:
 uninstall-scanner:
 	dotnet tool uninstall security-scan
 
-.PHONY: help build build-test-fw build-prod clean format install-cert install-tools install lint lint-scripts pre-release publish-all publish release restore scan setup sign test test-fw uninstall-scanner
+.PHONY: help build build-test-fw build-prod clean format install-cert install-tools install lint lint-scripts pre-release publish-all publish release restore scan setup-unix setup-win sign test test-fw uninstall-scanner

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# This script is used to download and install the required .NET versions
+
+# .NET versions we want to install
+declare -a NetVersions=("Current" "6.0" "5.0" "3.1" )
+
+# Download dotnet-install.sh
+echo "Downloading dotnet-install.sh script..."
+curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
+ 
+# Install each .NET version
+echo "Installing .NET versions..."
+for version in ${NetVersions[@]}; do
+   echo "Installing .NET $version..."
+   sudo bash ./dotnet-install.sh -c "$version"
+done
+
+# Remove dotnet-install.sh
+echo "Removing dotnet-install.sh script..."
+rm dotnet-install.sh

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -3,17 +3,17 @@
 # This script is used to download and install the required .NET versions
 
 # .NET versions we want to install
-declare -a NetVersions=("Current" "6.0" "5.0" "3.1" )
+declare -a NetVersions=("Current" "6.0" "5.0" "3.1")
 
 # Download dotnet-install.sh
 echo "Downloading dotnet-install.sh script..."
 curl -sSL https://dot.net/v1/dotnet-install.sh -o dotnet-install.sh
- 
+
 # Install each .NET version
 echo "Installing .NET versions..."
 for version in ${NetVersions[@]}; do
-   echo "Installing .NET $version..."
-   sudo bash ./dotnet-install.sh -c "$version"
+  echo "Installing .NET $version..."
+  sudo bash ./dotnet-install.sh -c "$version"
 done
 
 # Remove dotnet-install.sh


### PR DESCRIPTION
- Re-enable delay test
- Use Microsoft's [hosted dotnet-install script](https://learn.microsoft.com/en-us/dotnet/core/install/linux-scripted-manual#scripted-install) to install required .NET SDKs on Unix via Makefile script

Apologies about the branch name. Re-used the old branch (which is named something different on my local machine)
