### PR TITLE
Fix missing logger dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- Fix missing NuGet dependency for custom logger
+
 ## v0.5.0 (2022-10-04)
 
 - New feature: Set expiration time for interactions (how long since it was recorded should an interaction be considered valid)

--- a/EasyVCR/EasyVCR.csproj
+++ b/EasyVCR/EasyVCR.csproj
@@ -51,12 +51,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <None Include="..\README.md" Pack="true" PackagePath="\"/>
+        <None Include="..\README.md" Pack="true" PackagePath="\" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Add a missing NuGet dependency

Odd that this didn't show up in testing (was not installed in the EasyVCR project and ran fine without it), but EasyVCR will throw an error if used in a project without this dependency. Simply installing the dependency separately in the project solved the issue, so we'll include it as a dependency for EasyVCR to avoid users having to worry about installing it themselves.