### PR TITLE
Allow client cloning

### DIFF
--- a/EasyVCR.Tests/EasyVCR.Tests.csproj
+++ b/EasyVCR.Tests/EasyVCR.Tests.csproj
@@ -20,5 +20,6 @@
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+        <PackageReference Include="RestSharp" Version="108.0.2" />
     </ItemGroup>
 </Project>

--- a/EasyVCR.Tests/FakeDataService.cs
+++ b/EasyVCR.Tests/FakeDataService.cs
@@ -19,11 +19,11 @@ namespace EasyVCR.Tests
 
     public abstract class FakeDataService
     {
-        private readonly HttpClient? _client;
+        private readonly EasyVCRHttpClient? _client;
         private readonly string? _format;
         private readonly VCR? _vcr;
 
-        public HttpClient Client
+        public EasyVCRHttpClient Client
         {
             get
             {
@@ -31,7 +31,7 @@ namespace EasyVCR.Tests
 
                 if (_vcr != null) return _vcr.Client;
 
-                throw new InvalidOperationException("No VCR or HttpClient has been set.");
+                throw new InvalidOperationException("No VCR or EasyVcrHttpClient has been set.");
             }
         }
 
@@ -41,7 +41,7 @@ namespace EasyVCR.Tests
             _vcr = vcr;
         }
 
-        protected FakeDataService(string format, HttpClient client)
+        protected FakeDataService(string format, EasyVCRHttpClient client)
         {
             _format = format;
             _client = client;

--- a/EasyVCR.Tests/FakeJsonDataServiceImpl.cs
+++ b/EasyVCR.Tests/FakeJsonDataServiceImpl.cs
@@ -10,7 +10,7 @@ namespace EasyVCR.Tests
         {
         }
 
-        public FakeJsonDataService(HttpClient client) : base("json", client)
+        public FakeJsonDataService(EasyVCRHttpClient client) : base("json", client)
         {
         }
 
@@ -26,7 +26,7 @@ namespace EasyVCR.Tests
         {
         }
 
-        public FakeXmlDataService(HttpClient client) : base("xml", client)
+        public FakeXmlDataService(EasyVCRHttpClient client) : base("xml", client)
         {
         }
 

--- a/EasyVCR.Tests/Sample.cs
+++ b/EasyVCR.Tests/Sample.cs
@@ -82,7 +82,7 @@ namespace EasyVCR.Tests
         }
 
         /// <summary>
-        ///     Create a VCR, create a cassette, insert cassette into VCR, get the HttpClient from the VCR and make a request.
+        ///     Create a VCR, create a cassette, insert cassette into VCR, get the EasyVcrHttpClient from the VCR and make a request.
         /// </summary>
         public async Task SimpleVCRExample()
         {

--- a/EasyVCR.Tests/TestUtils.cs
+++ b/EasyVCR.Tests/TestUtils.cs
@@ -13,7 +13,7 @@ namespace EasyVCR.Tests
             return new Cassette(GetDirectoryInCurrentDirectory("cassettes"), cassetteName, order);
         }
 
-        internal static HttpClient GetSimpleClient(string cassetteName, Mode mode)
+        internal static EasyVCRHttpClient GetSimpleClient(string cassetteName, Mode mode)
         {
             var cassette = GetCassette(cassetteName);
             return HttpClients.NewHttpClient(cassette, mode);

--- a/EasyVCR.Tests/packages.lock.json
+++ b/EasyVCR.Tests/packages.lock.json
@@ -47,6 +47,15 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.2, )",
+        "resolved": "108.0.2",
+        "contentHash": "zI1lzI+Jjzl6bcicyUYfLIGmmOAdJRkYepMnSPzrxd1o9RxztPaR/blUOmY8BpXdN3I+XlK9dtwCYRGCxvaODw==",
+        "dependencies": {
+          "System.Text.Json": "5.0.0"
+        }
+      },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
         "resolved": "17.3.2",
@@ -976,6 +985,11 @@
           "System.Text.Encoding": "4.3.0"
         }
       },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
+      },
       "System.Text.RegularExpressions": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1109,6 +1123,15 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.2, )",
+        "resolved": "108.0.2",
+        "contentHash": "zI1lzI+Jjzl6bcicyUYfLIGmmOAdJRkYepMnSPzrxd1o9RxztPaR/blUOmY8BpXdN3I+XlK9dtwCYRGCxvaODw==",
+        "dependencies": {
+          "System.Text.Json": "5.0.0"
+        }
+      },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
@@ -1222,6 +1245,29 @@
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "EEslUvHKll1ftizbn20mX3Ix/l4Ygk/bdJ2LY6/X6FlGaP0RIhKMo9nS6JIGnKKT6KBP2PGj6JC3B9/ZF6ErqQ==",
+        "dependencies": {
+          "System.Memory": "4.5.4"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.4",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
+          "System.Text.Encodings.Web": "5.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4",
+          "System.ValueTuple": "4.5.0"
+        }
+      },
       "System.Threading.Tasks.Extensions": {
         "type": "Transitive",
         "resolved": "4.5.4",
@@ -1296,6 +1342,15 @@
         "requested": "[13.0.1, )",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.2, )",
+        "resolved": "108.0.2",
+        "contentHash": "zI1lzI+Jjzl6bcicyUYfLIGmmOAdJRkYepMnSPzrxd1o9RxztPaR/blUOmY8BpXdN3I+XlK9dtwCYRGCxvaODw==",
+        "dependencies": {
+          "System.Text.Json": "5.0.0"
+        }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
@@ -1497,8 +1552,8 @@
       },
       "System.Numerics.Vectors": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "UiLzLW+Lw6HLed1Hcg+8jSRttrbuXv7DANVj0DkL9g6EnnzbL75EB7EWsw5uRbhxd/4YdG8li5XizGWepmG3PQ=="
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
       },
       "System.Reflection": {
         "type": "Transitive",
@@ -1568,6 +1623,28 @@
           "System.Runtime": "4.3.0"
         }
       },
+      "System.Text.Encodings.Web": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "EEslUvHKll1ftizbn20mX3Ix/l4Ygk/bdJ2LY6/X6FlGaP0RIhKMo9nS6JIGnKKT6KBP2PGj6JC3B9/ZF6ErqQ==",
+        "dependencies": {
+          "System.Memory": "4.5.4"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw==",
+        "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "5.0.0",
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.4",
+          "System.Numerics.Vectors": "4.5.0",
+          "System.Runtime.CompilerServices.Unsafe": "5.0.0",
+          "System.Text.Encodings.Web": "5.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
+        }
+      },
       "System.Threading": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1635,6 +1712,15 @@
         "requested": "[13.0.1, )",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.2, )",
+        "resolved": "108.0.2",
+        "contentHash": "zI1lzI+Jjzl6bcicyUYfLIGmmOAdJRkYepMnSPzrxd1o9RxztPaR/blUOmY8BpXdN3I+XlK9dtwCYRGCxvaODw==",
+        "dependencies": {
+          "System.Text.Json": "5.0.0"
+        }
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
@@ -1897,6 +1983,11 @@
           "System.Runtime": "4.3.0"
         }
       },
+      "System.Text.Json": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "+luxMQNZ2WqeffBU7Ml6njIvxc8169NW2oU+ygNudXQGZiarjE7DOtN7bILiQjTZjkmwwRZGTtLzmdrSI/Ustw=="
+      },
       "System.Threading": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1956,6 +2047,12 @@
         "requested": "[13.0.1, )",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "RestSharp": {
+        "type": "Direct",
+        "requested": "[108.0.2, )",
+        "resolved": "108.0.2",
+        "contentHash": "zI1lzI+Jjzl6bcicyUYfLIGmmOAdJRkYepMnSPzrxd1o9RxztPaR/blUOmY8BpXdN3I+XlK9dtwCYRGCxvaODw=="
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",

--- a/EasyVCR/EasyVCRHttpClient.cs
+++ b/EasyVCR/EasyVCRHttpClient.cs
@@ -1,0 +1,41 @@
+using System.Net.Http;
+using EasyVCR.Handlers;
+
+// ReSharper disable InconsistentNaming
+
+namespace EasyVCR
+{
+    public class EasyVCRHttpClient : HttpClient
+    {
+        internal VCRHandler VcrHandler { get; }
+
+        internal EasyVCRHttpClient(VCRHandler vcrHandler) : base(vcrHandler)
+        {
+            VcrHandler = vcrHandler;
+        }
+
+        /// <summary>
+        ///     Create a clone of the current instance, with the same configuration.
+        /// </summary>
+        /// <returns>An EasyVcrHttpClient instance.</returns>
+        internal EasyVCRHttpClient Clone()
+        {
+            return new EasyVCRHttpClient(VcrHandler);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            if (obj is EasyVCRHttpClient other)
+            {
+                return VcrHandler.Equals(other.VcrHandler);
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return VcrHandler.GetHashCode();
+        }
+    }
+}

--- a/EasyVCR/HttpClients.cs
+++ b/EasyVCR/HttpClients.cs
@@ -7,61 +7,61 @@ using EasyVCR.Handlers;
 namespace EasyVCR
 {
     /// <summary>
-    ///     HttpClient singleton for EasyVCR.
+    ///     EasyVcrHttpClient singleton for EasyVCR.
     /// </summary>
     public static class HttpClients
     {
         /// <summary>
-        ///     Get a new HttpClient configured to use cassettes.
+        ///     Get a new EasyVcrHttpClient configured to use cassettes.
         /// </summary>
         /// <param name="cassetteFolder">Folder where cassettes will be stored.</param>
         /// <param name="cassetteName">Name of the cassette to use.</param>
         /// <param name="mode">Mode to operate in (i.e. Record, Replay, Auto, Bypass).</param>
         /// <param name="advancedSettings">AdvancedSettings object to use.</param>
-        /// <returns>An HttpClient object.</returns>
-        public static HttpClient NewHttpClient(string cassetteFolder, string cassetteName, Mode mode, AdvancedSettings? advancedSettings = null)
+        /// <returns>An EasyVcrHttpClient instance.</returns>
+        public static EasyVCRHttpClient NewHttpClient(string cassetteFolder, string cassetteName, Mode mode, AdvancedSettings? advancedSettings = null)
         {
             return NewHttpClientWithHandler(null, cassetteFolder, cassetteName, mode, advancedSettings);
         }
 
         /// <summary>
-        ///     Get a new HttpClient configured to use cassettes.
+        ///     Get a new EasyVcrHttpClient configured to use cassettes.
         /// </summary>
         /// <param name="cassette">Cassette object to use.</param>
         /// <param name="mode">Mode to operate in (i.e. Record, Replay, Auto, Bypass).</param>
         /// <param name="advancedSettings">AdvancedSettings object to use.</param>
-        /// <returns>An HttpClient object.</returns>
-        public static HttpClient NewHttpClient(Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
+        /// <returns>An EasyVcrHttpClient instance.</returns>
+        public static EasyVCRHttpClient NewHttpClient(Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
         {
             return NewHttpClientWithHandler(null, cassette, mode, advancedSettings);
         }
 
         /// <summary>
-        ///     Get a new HttpClient configured to use cassettes.
+        ///     Get a new EasyVcrHttpClient configured to use cassettes.
         /// </summary>
         /// <param name="innerHandler">Custom inner handler to execute as part of HTTP requests.</param>
         /// <param name="cassetteFolder">Folder where cassettes will be stored.</param>
         /// <param name="cassetteName">Name of the cassette to use.</param>
         /// <param name="mode">Mode to operate in (i.e. Record, Replay, Auto, Bypass).</param>
         /// <param name="advancedSettings">AdvancedSettings object to use.</param>
-        /// <returns>An HttpClient object.</returns>
-        public static HttpClient NewHttpClientWithHandler(HttpMessageHandler? innerHandler, string cassetteFolder, string cassetteName, Mode mode, AdvancedSettings? advancedSettings = null)
+        /// <returns>An EasyVcrHttpClient instance.</returns>
+        public static EasyVCRHttpClient NewHttpClientWithHandler(HttpMessageHandler? innerHandler, string cassetteFolder, string cassetteName, Mode mode, AdvancedSettings? advancedSettings = null)
         {
             return NewHttpClientWithHandler(innerHandler, new Cassette(cassetteFolder, cassetteName), mode, advancedSettings);
         }
 
         /// <summary>
-        ///     Get a new HttpClient configured to use cassettes.
+        ///     Get a new EasyVcrHttpClient configured to use cassettes.
         /// </summary>
         /// <param name="innerHandler">Custom inner handler to execute as part of HTTP requests.</param>
         /// <param name="cassette">Cassette object to use.</param>
         /// <param name="mode">Mode to operate in (i.e. Record, Replay, Auto, Bypass).</param>
         /// <param name="advancedSettings">AdvancedSettings object to use.</param>
-        /// <returns>An HttpClient object.</returns>
-        public static HttpClient NewHttpClientWithHandler(HttpMessageHandler? innerHandler, Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
+        /// <returns>An EasyVcrHttpClient instance.</returns>
+        public static EasyVCRHttpClient NewHttpClientWithHandler(HttpMessageHandler? innerHandler, Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
         {
             innerHandler ??= new HttpClientHandler();
-            return new HttpClient(new VCRHandler(innerHandler, cassette, mode, advancedSettings));
+            return new EasyVCRHttpClient(new VCRHandler(innerHandler, cassette, mode, advancedSettings));
         }
     }
 }

--- a/EasyVCR/VCR.cs
+++ b/EasyVCR/VCR.cs
@@ -29,7 +29,7 @@ namespace EasyVCR
         ///     Retrieve a pre-configured HTTP client that will use the VCR.
         /// </summary>
         /// <exception cref="InvalidOperationException">The VCR has no cassette</exception>
-        public HttpClient Client
+        public EasyVCRHttpClient Client
         {
             get
             {
@@ -68,6 +68,16 @@ namespace EasyVCR
             Mode = Mode.Auto;
         }
 
+        /// <summary>
+        ///     Create a clone of the VCR's pre-configured HTTP client.
+        /// </summary>
+        /// <returns>A pre-configured HTTP client that will use the VCR.</returns>
+        public EasyVCRHttpClient CloneClient()
+        {
+            // The Client property always generates a new client, so we can just use that.
+            return Client;
+        }
+        
         /// <summary>
         ///     Remove the current cassette from the VCR.
         /// </summary>

--- a/EasyVCR/VCR.cs
+++ b/EasyVCR/VCR.cs
@@ -77,7 +77,7 @@ namespace EasyVCR
             // The Client property always generates a new client, so we can just use that.
             return Client;
         }
-        
+
         /// <summary>
         ///     Remove the current cassette from the VCR.
         /// </summary>

--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ using EasyVCR;
 // Create a cassette to handle HTTP interactions
 var cassette = new Cassette("path/to/cassettes", "my_cassette");
 
-// create an HttpClient using the cassette
+// create an EasyVcrHttpClient using the cassette
 var recordingHttpClient = HttpClients.NewHttpClient(cassette, Mode.Record);
 
-// Use this HttpClient in any class making HTTP calls
+// Use this EasyVcrHttpClient in any class making HTTP calls
+// Note: EasyVcrHttpClient implements HttpClient, so it can be used anywhere a HttpClient is expected
 // For example, RestSharp v107+ supports custom HTTP clients
 RestClient restClient = new RestClient(recordingHttpClient, new RestClientOptions()));
 
@@ -40,7 +41,7 @@ using EasyVCR;
 // Create a cassette to handle HTTP interactions
 var cassette = new Cassette("path/to/cassettes", "my_cassette");
 
-// create an HttpClient using the cassette
+// create an EasyVcrHttpClient using the cassette
 var replayingHttpClient = HttpClients.NewHttpClient(cassette, Mode.Replay);
 ```
 
@@ -86,7 +87,8 @@ var httpClient = HttpClients.NewHttpClient(cassette, Mode.Record, advancedSettin
 
 Simulate a delay when replaying a recorded request, either using a specified delay or the original request duration.
 
-NOTE: Delays may suffer from a small margin of error on certain .NET versions. Do not rely on the delay being exact down to the millisecond.
+NOTE: Delays may suffer from a small margin of error on certain .NET versions. Do not rely on the delay being exact down
+to the millisecond.
 
 **Default**: *No delay*
 


### PR DESCRIPTION
One of the unit tests in EasyPost's C# library has revealed a fault with EasyVCR, namely that a VCR HttpClient cannot be re-used in a new RestSharp.RestClient instance. This really comes down to an issue with how RestClientOptions work (see `TestClientClone` unit test for a walkthrough of how/why this works); this PR circumvents this issue by adding a way for users to effectively "clone" a VCR client in case they need a new copy of the instance.

- New EasyVCRHttpClient class (implements HttpClient) to allow for middle-man modifications
- New EasyVCRHttpClient class allows clients to be "cloned"
- Call out that EasyVCRHttpClient can be used as a normal HttpClient
- New unit tests to verify casting and cloning of EasyVCRHttpClient