### PR TITLE
Account for non-JSON body when checking match by body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Next Release
+
+- [BUGFIX] Fix bug that would throw error if trying to "match by body" with non-JSON bodies.
+
 ## v0.7.0 (2022-11-15)
 
 - Add support for .NET 7

--- a/EasyVCR.Tests/EasyVCR.Tests.csproj
+++ b/EasyVCR.Tests/EasyVCR.Tests.csproj
@@ -26,4 +26,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
+    <ItemGroup>
+      <Reference Include="System.Web" />
+    </ItemGroup>
 </Project>

--- a/EasyVCR/MatchRules.cs
+++ b/EasyVCR/MatchRules.cs
@@ -69,8 +69,23 @@ namespace EasyVCR
                     // one has a null body, so they don't match
                     return false;
 
-                var receivedBody = JsonSerialization.NormalizeJson(received.Body, ignoredElements);
-                var recordedBody = JsonSerialization.NormalizeJson(recorded.Body, ignoredElements);
+                var receivedBody = received.Body;
+                var recordedBody = recorded.Body;
+                try
+                {
+                    receivedBody = JsonSerialization.NormalizeJson(received.Body, ignoredElements);
+                } catch (Exception)
+                {
+                    // not JSON, using the string as it is
+                }
+                
+                try
+                {
+                    recordedBody = JsonSerialization.NormalizeJson(recorded.Body, ignoredElements);
+                } catch (Exception)
+                {
+                    // not JSON, using the string as it is
+                }
 
                 if (receivedBody == null && recordedBody == null)
                     // both have empty string bodies, so they match

--- a/EasyVCR/MatchRules.cs
+++ b/EasyVCR/MatchRules.cs
@@ -74,15 +74,17 @@ namespace EasyVCR
                 try
                 {
                     receivedBody = JsonSerialization.NormalizeJson(received.Body, ignoredElements);
-                } catch (Exception)
+                }
+                catch (Exception)
                 {
                     // not JSON, using the string as it is
                 }
-                
+
                 try
                 {
                     recordedBody = JsonSerialization.NormalizeJson(recorded.Body, ignoredElements);
-                } catch (Exception)
+                }
+                catch (Exception)
                 {
                     // not JSON, using the string as it is
                 }


### PR DESCRIPTION
- VCR will no longer error if the body of a request is not JSON and match by body is enforced
- New unit test, manually verified that patch works