### PR TITLE
Add ability to censor URL path elements via regex patterns

### DIFF
--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -155,7 +155,6 @@ namespace EasyVCR.Tests
             var fakeDataService = new FakeJsonDataService(client);
             var _ = await fakeDataService.GetIPAddressDataRawResponse();
 
-            
             // verify that censoring does not interfere with replay
             client = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
             fakeDataService = new FakeJsonDataService(client);

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -132,7 +132,7 @@ namespace EasyVCR.Tests
         {
             var cassette = TestUtils.GetCassette("test_regex_censors");
             cassette.Erase(); // Erase cassette before recording
-            
+
             // set up regex pattern
             var url = new Uri(FakeDataService.GetIPAddressDataUrl());
             var domain = url.Host;
@@ -144,16 +144,16 @@ namespace EasyVCR.Tests
             {
                 Censors = new Censors(censorString).CensorPathElementsByPatterns(new List<string> { regexPattern })
             };
-            
+
             // record cassette with advanced settings
             var client = HttpClients.NewHttpClient(cassette, Mode.Record, advancedSettings);
             var fakeDataService = new FakeJsonDataService(client);
             var _ = await fakeDataService.GetIPAddressDataRawResponse();
-            
+
             // manually check that the cassette contains the censored path element
-            
+
             // verify that censoring does not interfere with replay
-            
+
             client = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
             fakeDataService = new FakeJsonDataService(client);
             var response = await fakeDataService.GetIPAddressDataRawResponse();

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -127,6 +127,11 @@ namespace EasyVCR.Tests
             Assert.AreEqual(censoredHeader, censorString);
         }
 
+        /// <summary>
+        ///     Test that the RegexCensor works as expected.
+        ///     NOTE: This test does not currently programmatically verify that the RegexCensor is working as expected.
+        ///     Instead, it relies on the developer to manually verify that the cassette file contains the expected censored values.
+        /// </summary>
         [TestMethod]
         public async Task TestRegexCensors()
         {
@@ -150,10 +155,8 @@ namespace EasyVCR.Tests
             var fakeDataService = new FakeJsonDataService(client);
             var _ = await fakeDataService.GetIPAddressDataRawResponse();
 
-            // manually check that the cassette contains the censored path element
-
+            
             // verify that censoring does not interfere with replay
-
             client = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
             fakeDataService = new FakeJsonDataService(client);
             var response = await fakeDataService.GetIPAddressDataRawResponse();

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -151,6 +151,13 @@ namespace EasyVCR.Tests
             var _ = await fakeDataService.GetIPAddressDataRawResponse();
             
             // manually check that the cassette contains the censored path element
+            
+            // verify that censoring does not interfere with replay
+            
+            client = HttpClients.NewHttpClient(cassette, Mode.Replay, advancedSettings);
+            fakeDataService = new FakeJsonDataService(client);
+            var response = await fakeDataService.GetIPAddressDataRawResponse();
+            Assert.IsNotNull(response);
         }
 
         [TestMethod]

--- a/EasyVCR.Tests/FakeDataService.cs
+++ b/EasyVCR.Tests/FakeDataService.cs
@@ -55,14 +55,19 @@ namespace EasyVCR.Tests
 
         public async Task<HttpResponseMessage> GetIPAddressDataRawResponse()
         {
-            return await Client.GetAsync(GetIPAddressDataUrl(_format));
+            return await Client.GetAsync(GetPreparedIPAddressDataUrl(_format));
         }
 
         protected abstract IPAddressData Convert(string responseBody);
 
-        public static string GetIPAddressDataUrl(string? format)
+        public static string GetPreparedIPAddressDataUrl(string? format)
         {
-            return $"https://api.ipify.org/?format={format}";
+            return $"{GetIPAddressDataUrl()}?format={format}";
+        }
+
+        public static string GetIPAddressDataUrl()
+        {
+            return "https://api.ipify.org/";
         }
     }
 }

--- a/EasyVCR/CensorElement.cs
+++ b/EasyVCR/CensorElement.cs
@@ -46,7 +46,7 @@ namespace EasyVCR
         public RegexCensorElement(string pattern, bool caseSensitive) : base(pattern, caseSensitive)
         {
         }
-        
+
         /// <summary>
         ///     Replace the provided value with the provided replacement if the value matches the regex pattern.
         ///     Returns the original value if the value does not match the regex pattern.
@@ -61,14 +61,14 @@ namespace EasyVCR
             {
                 options |= RegexOptions.IgnoreCase;
             }
-            
+
             return Regex.Replace(value,
                 Value,
                 replacement,
                 options,
                 TimeSpan.FromMilliseconds(250));
         }
-        
+
         /// <summary>
         ///     Checks whether the provided element matches this censor element, accounting for case sensitivity.
         /// </summary>

--- a/EasyVCR/CensorElement.cs
+++ b/EasyVCR/CensorElement.cs
@@ -86,10 +86,12 @@ namespace EasyVCR
 
             try
             {
-                return Regex.IsMatch(value,
+                return Regex.IsMatch(
+                    value,
                     Value,
                     options,
-                    TimeSpan.FromMilliseconds(250));
+                    TimeSpan.FromMilliseconds(250)
+                    );
             }
             catch (RegexMatchTimeoutException)
             {

--- a/EasyVCR/CensorElement.cs
+++ b/EasyVCR/CensorElement.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.RegularExpressions;
 
 namespace EasyVCR
 {
@@ -7,20 +8,20 @@ namespace EasyVCR
         /// <summary>
         ///     Whether the name is case-sensitive.
         /// </summary>
-        private bool CaseSensitive { get; }
+        protected bool CaseSensitive { get; }
         /// <summary>
         ///     Name of the element to censor.
         /// </summary>
-        private string Name { get; }
+        protected string Value { get; }
 
         /// <summary>
         ///     Constructor for a new censor element.
         /// </summary>
-        /// <param name="name">Name of the element to censor.</param>
+        /// <param name="value">Name of the element to censor.</param>
         /// <param name="caseSensitive">Whether the name is case-sensitive.</param>
-        public CensorElement(string name, bool caseSensitive)
+        public CensorElement(string value, bool caseSensitive)
         {
-            Name = name;
+            Value = value;
             CaseSensitive = caseSensitive;
         }
 
@@ -29,9 +30,69 @@ namespace EasyVCR
         /// </summary>
         /// <param name="key">The name to check.</param>
         /// <returns>True if the element matches, false otherwise.</returns>
-        internal bool Matches(string key)
+        internal virtual bool Matches(string key)
         {
-            return CaseSensitive ? Name.Equals(key) : Name.Equals(key, StringComparison.OrdinalIgnoreCase);
+            return CaseSensitive ? Value.Equals(key) : Value.Equals(key, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    public class RegexCensorElement : CensorElement
+    {
+        /// <summary>
+        ///     Constructor for a new regex censor element.
+        /// </summary>
+        /// <param name="pattern">Pattern of the element to censor.</param>
+        /// <param name="caseSensitive">Whether the pattern is case-sensitive.</param>
+        public RegexCensorElement(string pattern, bool caseSensitive) : base(pattern, caseSensitive)
+        {
+        }
+        
+        /// <summary>
+        ///     Replace the provided value with the provided replacement if the value matches the regex pattern.
+        ///     Returns the original value if the value does not match the regex pattern.
+        /// </summary>
+        /// <param name="value">Value to apply the replacement to.</param>
+        /// <param name="replacement">Replacement for a detected matching section.</param>
+        /// <returns>The value with the replacement inserted, or the original value if no match was found.</returns>
+        internal string MatchAndReplaceAsNeeded(string value, string replacement)
+        {
+            var options = RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.Singleline;
+            if (!CaseSensitive)
+            {
+                options |= RegexOptions.IgnoreCase;
+            }
+            
+            return Regex.Replace(value,
+                Value,
+                replacement,
+                options,
+                TimeSpan.FromMilliseconds(250));
+        }
+        
+        /// <summary>
+        ///     Checks whether the provided element matches this censor element, accounting for case sensitivity.
+        /// </summary>
+        /// <param name="value">The value to check.</param>
+        /// <returns>True if the element matches, false otherwise.</returns>
+        internal override bool Matches(string value)
+        {
+            var options = RegexOptions.Compiled | RegexOptions.CultureInvariant | RegexOptions.ExplicitCapture | RegexOptions.Singleline;
+            if (!CaseSensitive)
+            {
+                options |= RegexOptions.IgnoreCase;
+            }
+
+            try
+            {
+                return Regex.IsMatch(value,
+                    Value,
+                    options,
+                    TimeSpan.FromMilliseconds(250));
+            }
+            catch (RegexMatchTimeoutException)
+            {
+                return false;
+            }
         }
     }
 }

--- a/EasyVCR/CensorElement.cs
+++ b/EasyVCR/CensorElement.cs
@@ -62,11 +62,13 @@ namespace EasyVCR
                 options |= RegexOptions.IgnoreCase;
             }
 
-            return Regex.Replace(value,
+            return Regex.Replace(
+                value,
                 Value,
                 replacement,
                 options,
-                TimeSpan.FromMilliseconds(250));
+                TimeSpan.FromMilliseconds(250)
+            );
         }
 
         /// <summary>

--- a/EasyVCR/Censors.cs
+++ b/EasyVCR/Censors.cs
@@ -248,8 +248,8 @@ namespace EasyVCR
             }
 
             var uri = new Uri(url);
-
-            var path = uri.GetLeftPart(UriPartial.Path);
+            
+            var path = uri.GetLeftPart(UriPartial.Path); // bad function name, Microsoft. This gets the indicated portion of a URI (here, the full path minus query), not the left part of the path.
             var query = uri.Query;
             var queryParameters = HttpUtility.ParseQueryString(query);
 
@@ -335,7 +335,7 @@ namespace EasyVCR
             var uri = new Uri(url);
             var queryParameters = HttpUtility.ParseQueryString(uri.Query);
 
-            var path = uri.GetLeftPart(UriPartial.Path);
+            var path = uri.GetLeftPart(UriPartial.Path); // bad function name, Microsoft. This gets the indicated portion of a URI (here, the full path minus query), not the left part of the path.
 
             foreach (var pathCensor in _pathElementsToCensor)
             {

--- a/EasyVCR/Censors.cs
+++ b/EasyVCR/Censors.cs
@@ -248,7 +248,7 @@ namespace EasyVCR
             }
 
             var uri = new Uri(url);
-            
+
             var path = uri.GetLeftPart(UriPartial.Path); // bad function name, Microsoft. This gets the indicated portion of a URI (here, the full path minus query), not the left part of the path.
             var query = uri.Query;
             var queryParameters = HttpUtility.ParseQueryString(query);

--- a/EasyVCR/Censors.cs
+++ b/EasyVCR/Censors.cs
@@ -139,7 +139,7 @@ namespace EasyVCR
 
             return this;
         }
-        
+
         /// <summary>
         ///     Add a rule to censor specified path elements.
         /// </summary>
@@ -240,7 +240,7 @@ namespace EasyVCR
                 // short circuit if url is null
                 return url;
             }
-            
+
             if (_queryParamsToCensor.Count == 0 && _pathElementsToCensor.Count == 0)
             {
                 // short circuit if there are no censors to apply
@@ -255,7 +255,7 @@ namespace EasyVCR
 
             string censoredPath;
             string? censoredQueryString;
-            
+
             if (_pathElementsToCensor.Count == 0)
             {
                 // don't need to censor path elements
@@ -272,7 +272,7 @@ namespace EasyVCR
 
                 censoredPath = tempPath;
             }
-            
+
             if (queryParameters.Count == 0)
             {
                 // no query parameters to censor
@@ -298,18 +298,18 @@ namespace EasyVCR
                         }
                         censoredQueryParameters.Add(key, ElementShouldBeCensored(key, _queryParamsToCensor) ? _censorText : queryParameters[key]);
                     }
-                    
+
                     censoredQueryString = ToQueryString(censoredQueryParameters);
                 }
             }
-            
+
             // build censored url
             var censoredUrl = censoredPath;
             if (censoredQueryString != null)
             {
                 censoredUrl += $"?{censoredQueryString}";
             }
-            
+
             return censoredUrl;
         }
 
@@ -325,7 +325,7 @@ namespace EasyVCR
                 // short circuit if url is null
                 return url;
             }
-            
+
             if (_pathElementsToCensor.Count == 0)
             {
                 // short circuit if there are no censors to apply
@@ -334,7 +334,7 @@ namespace EasyVCR
 
             var uri = new Uri(url);
             var queryParameters = HttpUtility.ParseQueryString(uri.Query);
-            
+
             var path = uri.GetLeftPart(UriPartial.Path);
 
             foreach (var pathCensor in _pathElementsToCensor)
@@ -343,7 +343,7 @@ namespace EasyVCR
             }
 
             var censoredUrl = path;
-            
+
             if (queryParameters.Count > 0)
             {
                 censoredUrl = $"{censoredUrl}?{ToQueryString(queryParameters)}";

--- a/EasyVCR/InternalUtilities/DefaultInteractionConverter.cs
+++ b/EasyVCR/InternalUtilities/DefaultInteractionConverter.cs
@@ -46,7 +46,7 @@ namespace EasyVCR.InternalUtilities
             var request = new Request
             {
                 Method = httpRequestMessage.Method.ToString(),
-                Uri = censors.ApplyQueryParametersCensors(httpRequestMessage.RequestUri?.ToString()),
+                Uri = censors.ApplyUrlCensors(httpRequestMessage.RequestUri?.ToString()),
                 RequestHeaders = censors.ApplyHeaderCensors(ToHeaders(httpRequestMessage.Headers)),
                 ContentHeaders = censors.ApplyHeaderCensors(ToContentHeaders(httpRequestMessage.Content)),
                 BodyContentType = ContentTypeExtensions.DetermineContentType(requestBody)

--- a/README.md
+++ b/README.md
@@ -65,10 +65,14 @@ file.
 
 ### Censoring
 
-Censor sensitive data in the request and response bodies and headers, such as API keys and auth tokens.
+Censor sensitive data in the request and response, such as API keys and auth tokens.
 
-NOTE: This feature currently only works on JSON response bodies.
-
+Can censor:
+- Request and response headers (via key name)
+- Request and response bodies (via key name) (JSON only)
+- Request query parameters (via key name)
+- Request URL path elements (via regex pattern matching)
+- 
 **Default**: *Disabled*
 
 ```csharp
@@ -78,6 +82,7 @@ var cassette = new Cassette("path/to/cassettes", "my_cassette");
 
 var censors = new Censors().CensorHeadersByKeys(new List<string> { "Authorization" }) // Hide the Authorization header
 censors.CensorBodyElementsByKeys(new List<CensorElement> { new CensorElement("table", true) }); // Hide the table element (case sensitive) in the request and response body
+censors.CensorPathElementsByPatterns(new List<string> { ".*\\d{4}.*" }); // Hide any path element that contains 4 digits
 
 var advancedOptions = new AdvancedOptions()
 {


### PR DESCRIPTION
Users can now censor parts of their recorded URLs based on regex patterns, in case sensitive information is included in the URL path.

Unit test currently not programmatically verifying accuracy (no assertions), have to manually verify cassette is properly censored:
<img width="444" alt="image" src="https://user-images.githubusercontent.com/17054780/207999133-e31b901e-a29a-44b0-abf5-9204db5bd740.png">
