### PR TITLE
Add ability to create only VCRHandler

### DIFF
--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -6,8 +6,10 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web;
+using EasyVCR.Handlers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using RestSharp;
+// ReSharper disable InconsistentNaming
 
 namespace EasyVCR.Tests
 {
@@ -162,6 +164,9 @@ namespace EasyVCR.Tests
             Assert.IsNotNull(response);
         }
 
+        /// <summary>
+        ///     This test confirms that the <see cref="EasyVCRHttpClient"/> is constructed correctly.
+        /// </summary>
         [TestMethod]
         public void TestClient()
         {
@@ -170,13 +175,36 @@ namespace EasyVCR.Tests
             Assert.IsNotNull(client);
         }
 
+        /// <summary>
+        ///     This test confirms that users can construct their own <see cref="VCRHandler"/> for their own needs,
+        ///     if they don't want to use the pre-configured <see cref="EasyVCRHttpClient"/>.
+        /// </summary>
         [TestMethod]
-        public void TestDelegatingHandler()
+        public void TestVCRHandler()
         {
-            var vcrHandler = TestUtils.GetSimpleDelegatingHandler("test_client_handler", Mode.Bypass);
+            var cassette = TestUtils.GetCassette("test_client_handler");
+            const Mode mode = Mode.Bypass;
+
+            var vcrHandler = VCRHandler.NewVCRHandler(cassette, mode);
 
             Assert.IsNotNull(vcrHandler);
             Assert.IsNull(vcrHandler.InnerHandler);
+        }
+
+        /// <summary>
+        ///     This test confirms that users can construct their own <see cref="VCRHandler"/> for their own needs,
+        ///     with its own inner handler, if they don't want to use the pre-configured <see cref="EasyVCRHttpClient"/>.
+        /// </summary>
+        [TestMethod]
+        public void TestVCRHandlerWithInnerHandler()
+        {
+            var cassette = TestUtils.GetCassette("test_client_handler_with_inner_handler");
+            const Mode mode = Mode.Bypass;
+
+            var vcrHandler = VCRHandler.NewVCRHandler(cassette, mode, innerHandler: new HttpClientHandler());
+
+            Assert.IsNotNull(vcrHandler);
+            Assert.IsNotNull(vcrHandler.InnerHandler);
         }
 
         [TestMethod]

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -171,6 +171,15 @@ namespace EasyVCR.Tests
         }
 
         [TestMethod]
+        public void TestDelegatingHandler()
+        {
+            var vcrHandler = TestUtils.GetSimpleDelegatingHandler("test_client_handler", Mode.Bypass);
+
+            Assert.IsNotNull(vcrHandler);
+            Assert.IsNull(vcrHandler.InnerHandler);
+        }
+
+        [TestMethod]
         public async Task TestDefaultRequestMatching()
         {
             // test that match by method and url works

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -214,7 +214,7 @@ namespace EasyVCR.Tests
             var cassette = TestUtils.GetCassette("test_default_request_matching");
             cassette.Erase(); // Erase cassette before recording
 
-            const string postUrl = "https://google.com";
+            const string postUrl = "http://httpbin.org/post";
             var postBody = new StringContent("{\"key\":\"value\"}");
 
             // record cassette first
@@ -425,7 +425,7 @@ namespace EasyVCR.Tests
             var cassette = TestUtils.GetCassette("test_match_non_json_body");
             cassette.Erase(); // Erase cassette before recording
 
-            const string url = "https://google.com";
+            const string url = "http://httpbin.org/post";
             var postData = HttpUtility.UrlEncode($"param1=name&param2=age", Encoding.UTF8);
             var data = Encoding.UTF8.GetBytes(postData);
             var content = new ByteArrayContent(data);
@@ -495,7 +495,7 @@ namespace EasyVCR.Tests
             var cassette = TestUtils.GetCassette("test_nested_censoring");
             cassette.Erase(); // Erase cassette before recording
 
-            const string postUrl = "https://google.com";
+            const string postUrl = "http://httpbin.org/post";
             var postBody = new StringContent("{\r\n  \"array\": [\r\n    \"array_1\",\r\n    \"array_2\",\r\n    \"array_3\"\r\n  ],\r\n  \"dict\": {\r\n    \"nested_array\": [\r\n      \"nested_array_1\",\r\n      \"nested_array_2\",\r\n      \"nested_array_3\"\r\n    ],\r\n    \"nested_dict\": {\r\n      \"nested_dict_1\": {\r\n        \"nested_dict_1_1\": {\r\n          \"nested_dict_1_1_1\": \"nested_dict_1_1_1_value\"\r\n        }\r\n      },\r\n      \"nested_dict_2\": {\r\n        \"nested_dict_2_1\": \"nested_dict_2_1_value\",\r\n        \"nested_dict_2_2\": \"nested_dict_2_2_value\"\r\n      }\r\n    },\r\n    \"dict_1\": \"dict_1_value\",\r\n    \"null_key\": null\r\n  }\r\n}");
             // set up advanced settings
             const string censorString = "censored-by-test";
@@ -520,7 +520,7 @@ namespace EasyVCR.Tests
             var cassette = TestUtils.GetCassette("test_strict_request_matching");
             cassette.Erase(); // Erase cassette before recording
 
-            const string postUrl = "https://google.com";
+            const string postUrl = "http://httpbin.org/post";
             var postBody = new StringContent("{\n  \"address\": {\n    \"name\": \"Jack Sparrow\",\n    \"company\": \"EasyPost\",\n    \"street1\": \"388 Townsend St\",\n    \"street2\": \"Apt 20\",\n    \"city\": \"San Francisco\",\n    \"state\": \"CA\",\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"phone\": \"5555555555\"\n  }\n}");
 
             // record cassette first

--- a/EasyVCR.Tests/TestUtils.cs
+++ b/EasyVCR.Tests/TestUtils.cs
@@ -19,6 +19,12 @@ namespace EasyVCR.Tests
             return HttpClients.NewHttpClient(cassette, mode);
         }
 
+        internal static DelegatingHandler GetSimpleDelegatingHandler(string cassetteName, Mode mode)
+        {
+            var cassette = GetCassette(cassetteName);
+            return HttpClients.NewDelegatingHandler(cassette, mode);
+        }
+
         // ReSharper disable once InconsistentNaming
         internal static VCR GetSimpleVCR(Mode mode)
         {

--- a/EasyVCR.Tests/TestUtils.cs
+++ b/EasyVCR.Tests/TestUtils.cs
@@ -2,7 +2,9 @@ using System;
 using System.IO;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
+using EasyVCR.Handlers;
 using EasyVCR.Interfaces;
+// ReSharper disable InconsistentNaming
 
 namespace EasyVCR.Tests
 {
@@ -19,18 +21,12 @@ namespace EasyVCR.Tests
             return HttpClients.NewHttpClient(cassette, mode);
         }
 
-        internal static DelegatingHandler GetSimpleDelegatingHandler(string cassetteName, Mode mode)
-        {
-            var cassette = GetCassette(cassetteName);
-            return HttpClients.NewDelegatingHandler(cassette, mode);
-        }
-
         // ReSharper disable once InconsistentNaming
         internal static VCR GetSimpleVCR(Mode mode)
         {
             var vcr = new VCR(new AdvancedSettings
             {
-                MatchRules = MatchRules.DefaultStrict
+                MatchRules = MatchRules.DefaultStrict,
             });
             switch (mode)
             {

--- a/EasyVCR/Handlers/VCRHandler.cs
+++ b/EasyVCR/Handlers/VCRHandler.cs
@@ -30,12 +30,15 @@ namespace EasyVCR.Handlers
         /// <summary>
         ///     Initializes a new instance of the <see cref="VCRHandler" /> class.
         /// </summary>
-        /// <param name="innerHandler">Inner handler to also execute on requests.</param>
         /// <param name="cassette">Cassette to use to record/replay requests.</param>
         /// <param name="mode">Mode to operate in.</param>
         /// <param name="advancedSettings">Advanced settings to use during recording/replaying, optional</param>
-        internal VCRHandler(Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
+        /// <param name="innerHandler">Inner handler to also execute on requests.</param>
+        private VCRHandler(Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null, HttpMessageHandler? innerHandler = null)
         {
+            if (innerHandler != null)
+                InnerHandler = innerHandler; // despite not being nullable, InnerHandler does not need to be set (is optional): https://learn.microsoft.com/en-us/dotnet/api/System.Net.Http.DelegatingHandler.InnerHandler
+
             _cassette = cassette;
             _mode = mode;
             _censors = advancedSettings?.Censors ?? new Censors();
@@ -49,6 +52,22 @@ namespace EasyVCR.Handlers
 
             // Will throw an exception if an invalid settings combination is provided.
             ExpirationActionExtensions.CheckCompatibleSettings(_whenExpired, _mode);
+        }
+
+        // ReSharper disable once InconsistentNaming
+        /// <summary>
+        ///     Creates a new VCRHandler.
+        ///     Available if you want to construct your own HTTP client rather than using the built-in <see cref="EasyVCRHttpClient"/>.
+        /// </summary>
+        /// <param name="cassette">Cassette object to use.</param>
+        /// <param name="mode">Mode to operate in (i.e. Record, Replay, Auto, Bypass).</param>
+        /// <param name="advancedSettings">AdvancedSettings object to use.</param>
+        /// <param name="innerHandler">Custom inner handler to execute as part of HTTP requests.</param>
+        /// <returns>A VCRHandler instance.</returns>
+        public static VCRHandler NewVCRHandler(Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null, HttpMessageHandler? innerHandler = null)
+        {
+            // This could be done by simply making the constructor public, but this falls in line with the other helper methods in HttpClients.cs
+            return new VCRHandler(cassette, mode, advancedSettings, innerHandler);
         }
 
         /// <summary>

--- a/EasyVCR/Handlers/VCRHandler.cs
+++ b/EasyVCR/Handlers/VCRHandler.cs
@@ -34,9 +34,8 @@ namespace EasyVCR.Handlers
         /// <param name="cassette">Cassette to use to record/replay requests.</param>
         /// <param name="mode">Mode to operate in.</param>
         /// <param name="advancedSettings">Advanced settings to use during recording/replaying, optional</param>
-        internal VCRHandler(HttpMessageHandler innerHandler, Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
+        internal VCRHandler(Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
         {
-            InnerHandler = innerHandler;
             _cassette = cassette;
             _mode = mode;
             _censors = advancedSettings?.Censors ?? new Censors();

--- a/EasyVCR/HttpClients.cs
+++ b/EasyVCR/HttpClients.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using EasyVCR.Handlers;
 
@@ -60,8 +61,16 @@ namespace EasyVCR
         /// <returns>An EasyVcrHttpClient instance.</returns>
         public static EasyVCRHttpClient NewHttpClientWithHandler(HttpMessageHandler? innerHandler, Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
         {
-            innerHandler ??= new HttpClientHandler();
-            return new EasyVCRHttpClient(new VCRHandler(innerHandler, cassette, mode, advancedSettings));
+            var vcrHandler = new VCRHandler(cassette, mode, advancedSettings)
+            {
+                InnerHandler = innerHandler ?? new HttpClientHandler()
+            };
+            return new EasyVCRHttpClient(vcrHandler);
+        }
+
+        public static DelegatingHandler NewDelegatingHandler(Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
+        {
+            return new VCRHandler(cassette, mode, advancedSettings);
         }
     }
 }

--- a/EasyVCR/HttpClients.cs
+++ b/EasyVCR/HttpClients.cs
@@ -61,16 +61,11 @@ namespace EasyVCR
         /// <returns>An EasyVcrHttpClient instance.</returns>
         public static EasyVCRHttpClient NewHttpClientWithHandler(HttpMessageHandler? innerHandler, Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
         {
-            var vcrHandler = new VCRHandler(cassette, mode, advancedSettings)
-            {
-                InnerHandler = innerHandler ?? new HttpClientHandler()
-            };
-            return new EasyVCRHttpClient(vcrHandler);
-        }
+            innerHandler ??= new HttpClientHandler();  // We always need to have an inner handler for our pre-configured EasyVCRHttpClient's VCRHandler.
 
-        public static DelegatingHandler NewDelegatingHandler(Cassette cassette, Mode mode, AdvancedSettings? advancedSettings = null)
-        {
-            return new VCRHandler(cassette, mode, advancedSettings);
+            var vcrHandler = VCRHandler.NewVCRHandler(cassette, mode, advancedSettings, innerHandler);
+
+            return new EasyVCRHttpClient(vcrHandler);
         }
     }
 }


### PR DESCRIPTION
This PR introduces a way for users to construct the underlying VCRHandler alone.

Currently, users can only use the VCR capabilities by using an `EasyVCRHTTPClient` pre-configured with the necessary inner VCRHandler for recording/replaying HTTP requests.

Now, a user can simply make a VCRHandler and pass it into their own HTTP client of choice.