### PR TITLE
Fix misalignment between AdvancedSettings defaults and VCRHandler constructor

### DIFF
--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -209,13 +209,14 @@ namespace EasyVCR.Tests
         }
 
         [TestMethod]
-        public async Task TestDefaultRequestMatching()
+        public async Task TestDefaultRequestMatchingWithAdvancedSettings()
         {
             // test that match by method and url works
             var cassette = TestUtils.GetCassette("test_default_request_matching");
             cassette.Erase(); // Erase cassette before recording
 
             const string postUrl = "http://httpbin.org/post";
+            const string postUrl2 = "http://httpbin.org/post?q=a";
             var postBody = new StringContent("{\"key\":\"value\"}");
 
             // record cassette first
@@ -225,7 +226,7 @@ namespace EasyVCR.Tests
             });
             var response = await client.PostAsync(postUrl, postBody);
 
-            // check that the request body was not matched (should be a live call)
+            // check that the request was not matched (should be a live call)
             Assert.IsNotNull(response);
             Assert.IsFalse(Utilities.ResponseCameFromRecording(response));
 
@@ -236,9 +237,44 @@ namespace EasyVCR.Tests
             });
             response = await client.PostAsync(postUrl, postBody);
 
-            // check that the request body was matched
+            // check that the request was matched
             Assert.IsNotNull(response);
             Assert.IsTrue(Utilities.ResponseCameFromRecording(response));
+
+            // check that the request was not matched (should be a live call)
+            await Assert.ThrowsExceptionAsync<VCRException>(() => client.PostAsync(postUrl2, postBody));
+
+        }
+
+        [TestMethod]
+        public async Task TestDefaultRequestMatching()
+        {
+            // test that match by method and url works
+            var cassette = TestUtils.GetCassette("test_default_request_matching");
+            cassette.Erase(); // Erase cassette before recording
+
+            const string postUrl = "http://httpbin.org/post";
+            const string postUrl2 = "http://httpbin.org/post?q=a";
+            var postBody = new StringContent("{\"key\":\"value\"}");
+
+            // record cassette first
+            var client = HttpClients.NewHttpClient(cassette, Mode.Record);
+            var response = await client.PostAsync(postUrl, postBody);
+
+            // check that the request was not matched (should be a live call)
+            Assert.IsNotNull(response);
+            Assert.IsFalse(Utilities.ResponseCameFromRecording(response));
+
+            // replay cassette
+            client = HttpClients.NewHttpClient(cassette, Mode.Replay);
+            response = await client.PostAsync(postUrl, postBody);
+
+            // check that the request was matched
+            Assert.IsNotNull(response);
+            Assert.IsTrue(Utilities.ResponseCameFromRecording(response));
+
+            // check that the request was not matched (should be a live call)
+            await Assert.ThrowsExceptionAsync<VCRException>(() => client.PostAsync(postUrl2, postBody));
         }
 
         [TestMethod]

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -207,6 +207,37 @@ namespace EasyVCR.Tests
             Assert.IsNotNull(vcrHandler);
             Assert.IsNotNull(vcrHandler.InnerHandler);
         }
+        
+        [TestMethod]
+        public async Task TestDefaultRequestMatching()
+        {
+            // test that match by method and url works
+            var cassette = TestUtils.GetCassette("test_default_request_matching");
+            cassette.Erase(); // Erase cassette before recording
+
+            const string postUrl1 = "https://httpbin.org/post?num=1";
+            const string postUrl2 = "https://httpbin.org/post?num=2";
+            var postBody = new StringContent("{\"key\":\"value\"}");
+
+            // record cassette first
+            var client = HttpClients.NewHttpClient(cassette, Mode.Record);
+            var response = await client.PostAsync(postUrl1, postBody);
+
+            // check that the request was not matched (should be a live call)
+            Assert.IsNotNull(response);
+            Assert.IsFalse(Utilities.ResponseCameFromRecording(response));
+
+            // replay cassette
+            client = HttpClients.NewHttpClient(cassette, Mode.Replay);
+            response = await client.PostAsync(postUrl1, postBody);
+
+            // check that the request was matched
+            Assert.IsNotNull(response);
+            Assert.IsTrue(Utilities.ResponseCameFromRecording(response));
+
+            // check that the request was not matched (should be a live call)
+            await Assert.ThrowsExceptionAsync<VCRException>(() => client.PostAsync(postUrl2, postBody));
+        }
 
         [TestMethod]
         public async Task TestDefaultRequestMatchingWithAdvancedSettings()
@@ -215,8 +246,8 @@ namespace EasyVCR.Tests
             var cassette = TestUtils.GetCassette("test_default_request_matching");
             cassette.Erase(); // Erase cassette before recording
 
-            const string postUrl = "http://httpbin.org/post";
-            const string postUrl2 = "http://httpbin.org/post?q=a";
+            const string postUrl1 = "https://httpbin.org/post?num=1";
+            const string postUrl2 = "https://httpbin.org/post?num=2";
             var postBody = new StringContent("{\"key\":\"value\"}");
 
             // record cassette first
@@ -224,7 +255,7 @@ namespace EasyVCR.Tests
             {
                 MatchRules = MatchRules.Default // doesn't really matter for initial record
             });
-            var response = await client.PostAsync(postUrl, postBody);
+            var response = await client.PostAsync(postUrl1, postBody);
 
             // check that the request was not matched (should be a live call)
             Assert.IsNotNull(response);
@@ -235,7 +266,7 @@ namespace EasyVCR.Tests
             {
                 MatchRules = MatchRules.Default
             });
-            response = await client.PostAsync(postUrl, postBody);
+            response = await client.PostAsync(postUrl1, postBody);
 
             // check that the request was matched
             Assert.IsNotNull(response);
@@ -244,37 +275,6 @@ namespace EasyVCR.Tests
             // check that the request was not matched (should be a live call)
             await Assert.ThrowsExceptionAsync<VCRException>(() => client.PostAsync(postUrl2, postBody));
 
-        }
-
-        [TestMethod]
-        public async Task TestDefaultRequestMatching()
-        {
-            // test that match by method and url works
-            var cassette = TestUtils.GetCassette("test_default_request_matching");
-            cassette.Erase(); // Erase cassette before recording
-
-            const string postUrl = "http://httpbin.org/post";
-            const string postUrl2 = "http://httpbin.org/post?q=a";
-            var postBody = new StringContent("{\"key\":\"value\"}");
-
-            // record cassette first
-            var client = HttpClients.NewHttpClient(cassette, Mode.Record);
-            var response = await client.PostAsync(postUrl, postBody);
-
-            // check that the request was not matched (should be a live call)
-            Assert.IsNotNull(response);
-            Assert.IsFalse(Utilities.ResponseCameFromRecording(response));
-
-            // replay cassette
-            client = HttpClients.NewHttpClient(cassette, Mode.Replay);
-            response = await client.PostAsync(postUrl, postBody);
-
-            // check that the request was matched
-            Assert.IsNotNull(response);
-            Assert.IsTrue(Utilities.ResponseCameFromRecording(response));
-
-            // check that the request was not matched (should be a live call)
-            await Assert.ThrowsExceptionAsync<VCRException>(() => client.PostAsync(postUrl2, postBody));
         }
 
         [TestMethod]
@@ -494,7 +494,7 @@ namespace EasyVCR.Tests
             var cassette = TestUtils.GetCassette("test_match_non_json_body");
             cassette.Erase(); // Erase cassette before recording
 
-            const string url = "http://httpbin.org/post";
+            const string url = "https://httpbin.org/post";
             var postData = HttpUtility.UrlEncode($"param1=name&param2=age", Encoding.UTF8);
             var data = Encoding.UTF8.GetBytes(postData);
             var content = new ByteArrayContent(data);
@@ -643,7 +643,7 @@ namespace EasyVCR.Tests
             var cassette = TestUtils.GetCassette("test_nested_censoring");
             cassette.Erase(); // Erase cassette before recording
 
-            const string postUrl = "http://httpbin.org/post";
+            const string postUrl = "https://httpbin.org/post";
             var postBody = new StringContent("{\r\n  \"array\": [\r\n    \"array_1\",\r\n    \"array_2\",\r\n    \"array_3\"\r\n  ],\r\n  \"dict\": {\r\n    \"nested_array\": [\r\n      \"nested_array_1\",\r\n      \"nested_array_2\",\r\n      \"nested_array_3\"\r\n    ],\r\n    \"nested_dict\": {\r\n      \"nested_dict_1\": {\r\n        \"nested_dict_1_1\": {\r\n          \"nested_dict_1_1_1\": \"nested_dict_1_1_1_value\"\r\n        }\r\n      },\r\n      \"nested_dict_2\": {\r\n        \"nested_dict_2_1\": \"nested_dict_2_1_value\",\r\n        \"nested_dict_2_2\": \"nested_dict_2_2_value\"\r\n      }\r\n    },\r\n    \"dict_1\": \"dict_1_value\",\r\n    \"null_key\": null\r\n  }\r\n}");
             // set up advanced settings
             const string censorString = "censored-by-test";
@@ -660,7 +660,7 @@ namespace EasyVCR.Tests
 
             // NOTE: Have to manually check the cassette
         }
-
+        
         [TestMethod]
         public async Task TestStrictRequestMatching()
         {
@@ -668,7 +668,7 @@ namespace EasyVCR.Tests
             var cassette = TestUtils.GetCassette("test_strict_request_matching");
             cassette.Erase(); // Erase cassette before recording
 
-            const string postUrl = "http://httpbin.org/post";
+            const string postUrl = "https://httpbin.org/post";
             var postBody = new StringContent("{\n  \"address\": {\n    \"name\": \"Jack Sparrow\",\n    \"company\": \"EasyPost\",\n    \"street1\": \"388 Townsend St\",\n    \"street2\": \"Apt 20\",\n    \"city\": \"San Francisco\",\n    \"state\": \"CA\",\n    \"zip\": \"94107\",\n    \"country\": \"US\",\n    \"phone\": \"5555555555\"\n  }\n}");
 
             // record cassette first

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -207,7 +207,7 @@ namespace EasyVCR.Tests
             Assert.IsNotNull(vcrHandler);
             Assert.IsNotNull(vcrHandler.InnerHandler);
         }
-        
+
         [TestMethod]
         public async Task TestDefaultRequestMatching()
         {
@@ -660,7 +660,7 @@ namespace EasyVCR.Tests
 
             // NOTE: Have to manually check the cassette
         }
-        
+
         [TestMethod]
         public async Task TestStrictRequestMatching()
         {

--- a/EasyVCR.Tests/FakeDataService.cs
+++ b/EasyVCR.Tests/FakeDataService.cs
@@ -72,7 +72,7 @@ namespace EasyVCR.Tests
 
         public static string GetPostManPostEchoServiceUrl()
         {
-            return "http://httpbin.org/post";
+            return "https://httpbin.org/post";
         }
     }
 }

--- a/EasyVCR/Handlers/VCRHandler.cs
+++ b/EasyVCR/Handlers/VCRHandler.cs
@@ -43,7 +43,7 @@ namespace EasyVCR.Handlers
             _mode = mode;
             _censors = advancedSettings?.Censors ?? new Censors();
             _interactionConverter = advancedSettings?.InteractionConverter ?? new DefaultInteractionConverter();
-            _matchRules = advancedSettings?.MatchRules ?? new MatchRules();
+            _matchRules = advancedSettings?.MatchRules ?? MatchRules.Default;
             _useOriginalDelay = advancedSettings?.SimulateDelay ?? false;
             _delay = advancedSettings?.ManualDelayTimeSpan ?? TimeSpan.Zero;
             _validTimeFrame = advancedSettings?.ValidTimeFrame ?? TimeFrame.Forever;


### PR DESCRIPTION
# Description

When `VCRHandler` is created with a null `AdvancedSettings`, or an `AdvancedSettings` with a null `MatchRules` property, then the handler `_matchRules` is set to a new instance of `MatchRules`. 
However, when `AdvancedSettings` is instanciated, it uses `MatchRules.Default` by default for its `MatchRules` property.
As passing no `AdvancedSettings` is expected to behave exactly like passing a default `AdvancedSettings` instance, this creates a bug, where if no `AdvancedSettings` is provided, all requests are matching by default.

# Testing

1 Unit tests has been updated, and another has been created to confirm the bug and the fix.

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
