### PR TITLE
Make Request properties and VCRHandler type public

### DIFF
--- a/EasyVCR/Handlers/VCRHandler.cs
+++ b/EasyVCR/Handlers/VCRHandler.cs
@@ -13,7 +13,7 @@ namespace EasyVCR.Handlers
     ///     A handler that records and replays HTTP requests and responses.
     /// </summary>
     // ReSharper disable once InconsistentNaming
-    internal class VCRHandler : DelegatingHandler
+    public class VCRHandler : DelegatingHandler
     {
         private readonly Cassette _cassette;
 

--- a/EasyVCR/RequestElements/Request.cs
+++ b/EasyVCR/RequestElements/Request.cs
@@ -38,7 +38,7 @@ namespace EasyVCR.RequestElements
         /// </summary>
         [JsonProperty("Method")]
         public string Method { get; set; }
-        
+
         /// <summary>
         ///     The request headers of the request.
         /// </summary>

--- a/EasyVCR/RequestElements/Request.cs
+++ b/EasyVCR/RequestElements/Request.cs
@@ -15,7 +15,7 @@ namespace EasyVCR.RequestElements
         ///     The body of the request.
         /// </summary>
         [JsonProperty("Body")]
-        internal string? Body { get; set; }
+        public string? Body { get; set; }
 
         /// <summary>
         ///     The content type of the body of the response.
@@ -31,22 +31,25 @@ namespace EasyVCR.RequestElements
         ///     The content headers of the request.
         /// </summary>
         [JsonProperty("ContentHeaders")]
-        internal IDictionary<string, string>? ContentHeaders { get; set; }
+        public IDictionary<string, string>? ContentHeaders { get; set; }
+
         /// <summary>
         ///     The method of the request.
         /// </summary>
         [JsonProperty("Method")]
-        internal string Method { get; set; }
+        public string Method { get; set; }
+        
         /// <summary>
         ///     The request headers of the request.
         /// </summary>
         [JsonProperty("RequestHeaders")]
-        internal IDictionary<string, string> RequestHeaders { get; set; }
+        public IDictionary<string, string> RequestHeaders { get; set; }
+
         /// <summary>
         ///    The URL of the request.
         /// </summary>
         [JsonProperty("Uri")]
-        internal string? Uri { get; set; }
+        public string? Uri { get; set; }
 
         /// <summary>
         ///     The content type of the body of the response (string).


### PR DESCRIPTION
# Description

The `Request` object has all its properties set to internal visibility.
However, it is exposed in the `IInteractionConverter` type under the assumption that an implementation living outside of EasyVCR would be able to return a fully hydrated instance.
More importantly, this defeats the purpose of the `MatchRules`.`ByCustomRule` method, which provides `Request` objects for `recorded` and `received` parameters, where the implementor can access absolutely nothing (except though reflection of course).
The test cases do not catch this due to `InternalsVisibleTo` being applied to the test assembly.

Also make the `VCRHandler` type public, as there is a specific test stating that its construction should be possible by a user of the library (`ClientTest`.`TestVCRHandler`).
It is especially needed to test code using https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-8.0, and dependency injection, especially to be able to inject the handler as indicated in https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-8.0#outgoing-request-middleware.

# Testing

I did not write any test.
If this was deemed necessary, then probably test assemblies should be split in two, one for testing the public usage of the library, another relying on internals ? Or an intermediary test utils assembly which would expose publicly methods to act on the internals for tests could be created, to ensure access to internals is under control in tests ?

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
