### PR TITLE
fix: avoid null exception when received body is empty but recorded body isn't

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Add .NET 8.0 support
 - `AdvancedSettings` uses `MatchRules.Default` instead of a new instance of `MatchRules` if not provided during construction
+- Fix `NullReferenceException` when trying to match by body with a null body (`refit` compatibility)
 
 ## v0.9.0 (2023-05-17)
 

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -512,7 +512,7 @@ namespace EasyVCR.Tests
             var response = await client.PostAsync(url, content);
             Assert.IsNotNull(response);
         }
-        
+
         [TestMethod]
         public async Task TestMatchEmptyStringBodyToNonEmptyStringBody()
         {
@@ -520,8 +520,7 @@ namespace EasyVCR.Tests
             cassette.Erase(); // Erase cassette before recording
 
             const string url = "https://httpbin.org/post";
-    
-            // record baseline request first
+
             var client = HttpClients.NewHttpClient(cassette, Mode.Record);
             var someContent = new ByteArrayContent(Encoding.UTF8.GetBytes("whatevs"));
             _ = await client.PostAsync(url, someContent);
@@ -534,7 +533,7 @@ namespace EasyVCR.Tests
             var emptyContent = new ByteArrayContent(Encoding.UTF8.GetBytes(string.Empty));
             Assert.ThrowsExceptionAsync<VCRException>(async () => await client.PostAsync(url, emptyContent), "No interaction found for request POST https://httpbin.org/post");
         }
-        
+
 
 
         [TestMethod]

--- a/EasyVCR.Tests/ClientTest.cs
+++ b/EasyVCR.Tests/ClientTest.cs
@@ -522,7 +522,7 @@ namespace EasyVCR.Tests
             const string url = "https://httpbin.org/post";
 
             var client = HttpClients.NewHttpClient(cassette, Mode.Record);
-            var someContent = new ByteArrayContent(Encoding.UTF8.GetBytes("whatevs"));
+            var someContent = new ByteArrayContent(Encoding.UTF8.GetBytes("non_empty_string_body"));
             _ = await client.PostAsync(url, someContent);
 
             // try to replay the request with match by body enforcement
@@ -531,10 +531,8 @@ namespace EasyVCR.Tests
                 MatchRules = new MatchRules().ByBody()
             });
             var emptyContent = new ByteArrayContent(Encoding.UTF8.GetBytes(string.Empty));
-            Assert.ThrowsExceptionAsync<VCRException>(async () => await client.PostAsync(url, emptyContent), "No interaction found for request POST https://httpbin.org/post");
+            await Assert.ThrowsExceptionAsync<VCRException>(async () => await client.PostAsync(url, emptyContent), $"No interaction found for request POST {url}");
         }
-
-
 
         [TestMethod]
         public async Task TestInteractionElements()

--- a/EasyVCR/InternalUtilities/Extensions.cs
+++ b/EasyVCR/InternalUtilities/Extensions.cs
@@ -1,0 +1,7 @@
+namespace EasyVCR.InternalUtilities
+{
+    public static class Extensions
+    {
+        public static bool IsEmptyStringOrNull(this string? str) => str == null || string.IsNullOrWhiteSpace(str);
+    }
+}

--- a/EasyVCR/MatchRules.cs
+++ b/EasyVCR/MatchRules.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Web;
+using EasyVCR.InternalUtilities;
 using EasyVCR.RequestElements;
 using JsonSerialization = EasyVCR.InternalUtilities.JSON.Serialization;
 using XmlSerialization = EasyVCR.InternalUtilities.XML.Serialization;
@@ -132,7 +133,7 @@ namespace EasyVCR
                     return true;
 
                 if (received.Body == null || recorded.Body == null)
-                    // one has a null body, so they don't match
+                    // one has a null body, the other does not, so they don't match
                     return false;
 
                 var receivedBody = received.Body;
@@ -155,11 +156,24 @@ namespace EasyVCR
                     // not JSON, using the string as it is
                 }
 
+                if (receivedBody.IsEmptyStringOrNull())
+                    // short-cut if the received body is empty
+                    receivedBody = null;
+
+                if (recordedBody.IsEmptyStringOrNull())
+                    // short-cut if the recorded body is empty
+                    recordedBody = null;
+
                 if (receivedBody == null && recordedBody == null)
                     // both have empty string bodies, so they match
                     return true;
 
-                return (receivedBody ?? "").Equals(recordedBody, StringComparison.OrdinalIgnoreCase);
+                if (receivedBody == null || recordedBody == null)
+                    // one has a null body, the other does not, so they don't match
+                    return false;
+
+                // if the bodies are not null, then we can compare them
+                return receivedBody.Equals(recordedBody, StringComparison.OrdinalIgnoreCase);
             });
             return this;
         }

--- a/EasyVCR/MatchRules.cs
+++ b/EasyVCR/MatchRules.cs
@@ -159,7 +159,7 @@ namespace EasyVCR
                     // both have empty string bodies, so they match
                     return true;
 
-                return receivedBody!.Equals(recordedBody, StringComparison.OrdinalIgnoreCase);
+                return (receivedBody ?? "").Equals(recordedBody, StringComparison.OrdinalIgnoreCase);
             });
             return this;
         }


### PR DESCRIPTION
Firstly, **thank you** so much for creating and maintaining this library 🙏 
I've been a VCR user in ruby, and have been looking for a comparable library for c# for a while.
Thank you for your hard work!

I encountered the issue below when using VCR in conjunction with the `refit` library (https://github.com/reactiveui/refit).
Refit would automatically assign an empty body to requests, unless defined otherwise.
I would then get null ref exception when trying to record a new request onto an existing cassette.

# Description

Closes #58

# Testing

Unit test added
# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
