### PR TITLE
[chore] Only run final CI step if triggered by a "release"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,9 @@ jobs:
       - name: Publish to NuGet
         run: make publish key=${{ secrets.NUGET_API_KEY }}
 
+      # If triggered by a release, upload the NuGet package to the release
       - name: Upload NuGet package to release
+        if: github.event_name == 'release'
         uses: AButler/upload-release-assets@v3.0
         with:
           files: "*.nupkg"


### PR DESCRIPTION
# Description

We recently added the ability to manually trigger the "publish via CI" process (it is also automatically triggered by cutting a new GitHub release).

The final step of the CI, however, anticipates the presence of variables that are only present when a release triggers the CI.

This PR adds logic to the CI process that will skip this step if triggered manually.

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
