### PR TITLE
[fix] Include .NET 8.0-compatible DLLs in NuGet package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v0.11.0 (2024-03-08)
+## v0.11.0 (2024-06-06)
 
 - Add missing .NET 8.0 DLLs to the NuGet package
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.11.0 (2024-03-08)
+
+- Add missing .NET 8.0 DLLs to the NuGet package
+
 ## v0.10.0 (2024-02-09)
 
 - Add .NET 8.0 support

--- a/EasyVCR.nuspec
+++ b/EasyVCR.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>EasyVCR</id>
         <title>EasyVCR</title>
-        <version>0.10.0</version>
+        <version>0.11.0</version>
         <authors>EasyPost</authors>
         <owners>EasyPost</owners>
         <projectUrl>https://github.com/EasyPost/easyvcr-csharp</projectUrl>
@@ -34,6 +34,10 @@
                 <dependency id="Newtonsoft.Json" version="13.0.1" />
                 <dependency id="Microsoft.Extensions.Logging" version="6.0.0" />
             </group>
+            <group targetFramework="net8.0">
+                <dependency id="Newtonsoft.Json" version="13.0.1" />
+                <dependency id="Microsoft.Extensions.Logging" version="6.0.0" />
+            </group>
         </dependencies>
     </metadata>
     <files>
@@ -47,6 +51,8 @@
         <file src="lib\net6.0\EasyVCR.XML" target="lib\net6.0" />
         <file src="lib\net7.0\EasyVCR.dll" target="lib\net7.0" />
         <file src="lib\net7.0\EasyVCR.XML" target="lib\net7.0" />
+        <file src="lib\net8.0\EasyVCR.dll" target="lib\net8.0" />
+        <file src="lib\net8.0\EasyVCR.XML" target="lib\net8.0" />
         <file src="README.md" target="docs\" />
         <file src="icon.png" target="images\" />
     </files>

--- a/EasyVCR/Properties/VersionInfo.cs
+++ b/EasyVCR/Properties/VersionInfo.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
 // Version information for an assembly must follow semantic versioning
-[assembly: AssemblyVersion("0.10.0")]
-[assembly: AssemblyFileVersion("0.10.0")]
-[assembly: AssemblyInformationalVersion("0.10.0")]
+[assembly: AssemblyVersion("0.11.0")]
+[assembly: AssemblyFileVersion("0.11.0")]
+[assembly: AssemblyInformationalVersion("0.11.0")]


### PR DESCRIPTION
# Description

v0.10.0 added .NET 8.0 support, but we forgot to include the .NET 8.0 binaries in the NuGet package (note .NET 8.0 is not highlighted on the project's NuGet page): 
<img width="856" alt="image" src="https://github.com/EasyPost/easyvcr-csharp/assets/17054780/5401fd21-dd08-41e1-8f1c-72dd4494e7bc">

# Testing

<!--
Please provide details on how you tested this code. See below.

- All pull requests must be tested (unit tests where possible with accompanying cassettes, or provide a screenshot of end-to-end testing when unit tests are not possible)
- New features must get a new unit test
- Bug fixes/refactors must re-record existing cassettes 
-->

# Pull Request Type

Please select the option(s) that are relevant to this PR.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement (fixing a typo, updating readme, renaming a variable name, etc)
