### PR TITLE
Replace extractions/setup-just with EasyPost/ep-actions setup/just action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
+        with:
+          os: windows
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x.x
@@ -25,7 +27,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
+        with:
+          os: windows
       - uses: actions/setup-dotnet@v5
         with:
           # v6 is needed for the tool to run
@@ -43,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x.x
@@ -59,7 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x.x
@@ -101,7 +105,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
+        with:
+          os: windows
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
@@ -153,7 +159,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
+        with:
+          os: windows
       - uses: actions/setup-dotnet@v5
         id: setupid
         with:
@@ -189,7 +197,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
+        with:
+          os: windows
       - uses: actions/setup-dotnet@v5
         id: setupid
         with:
@@ -225,7 +235,9 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
+        with:
+          os: windows
       - uses: actions/setup-dotnet@v5
         id: setupid
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - uses: EasyPost/ep-actions/.github/actions/setup/just@main
+        with:
+          os: windows
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |


### PR DESCRIPTION
## What

Replaces the unverified third-party action `extractions/setup-just` with the internal composite action [`EasyPost/ep-actions/.github/actions/setup/just@main`](https://github.com/EasyPost/ep-actions/tree/main/.github/actions/setup/just).

## Why

`extractions/setup-just` is a third-party action from an unverified publisher and is **not** on the approved list in `EasyPost/ep-actions/ApprovedThirdPartyActions.yaml`. Using the internal composite action keeps CI on a vetted, EasyPost-owned action.

## Notes

- This repo runs `just` on both Windows and Linux runners. The ep-actions action now supports cross-platform installs via the `os` input; Windows jobs pass `os: windows` while Linux jobs use the default (`linux`).