### PR TITLE
Install just via curl instead of extractions/setup-just

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,27 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - name: Install just
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP:-/tmp}/just-bin"
+          mkdir -p "$install_dir"
+          # Resolve the latest release tag via the github.com redirect to avoid
+          # api.github.com rate limits on shared runner egress IPs.
+          latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)
+          just_version="${latest_url##*/tag/}"
+          case "$RUNNER_OS" in
+            Windows) asset="just-${just_version}-x86_64-pc-windows-msvc.zip" ;;
+            macOS)   asset="just-${just_version}-x86_64-apple-darwin.tar.gz" ;;
+            *)       asset="just-${just_version}-x86_64-unknown-linux-musl.tar.gz" ;;
+          esac
+          curl -fL "https://github.com/casey/just/releases/download/${just_version}/${asset}" -o "$install_dir/$asset"
+          case "$asset" in
+            *.zip) unzip -o "$install_dir/$asset" -d "$install_dir" ;;
+            *)     tar -xzf "$install_dir/$asset" -C "$install_dir" ;;
+          esac
+          echo "$install_dir" >> "$GITHUB_PATH"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x.x
@@ -25,7 +45,27 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - name: Install just
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP:-/tmp}/just-bin"
+          mkdir -p "$install_dir"
+          # Resolve the latest release tag via the github.com redirect to avoid
+          # api.github.com rate limits on shared runner egress IPs.
+          latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)
+          just_version="${latest_url##*/tag/}"
+          case "$RUNNER_OS" in
+            Windows) asset="just-${just_version}-x86_64-pc-windows-msvc.zip" ;;
+            macOS)   asset="just-${just_version}-x86_64-apple-darwin.tar.gz" ;;
+            *)       asset="just-${just_version}-x86_64-unknown-linux-musl.tar.gz" ;;
+          esac
+          curl -fL "https://github.com/casey/just/releases/download/${just_version}/${asset}" -o "$install_dir/$asset"
+          case "$asset" in
+            *.zip) unzip -o "$install_dir/$asset" -d "$install_dir" ;;
+            *)     tar -xzf "$install_dir/$asset" -C "$install_dir" ;;
+          esac
+          echo "$install_dir" >> "$GITHUB_PATH"
       - uses: actions/setup-dotnet@v5
         with:
           # v6 is needed for the tool to run
@@ -43,7 +83,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - name: Install just
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP:-/tmp}/just-bin"
+          mkdir -p "$install_dir"
+          # Resolve the latest release tag via the github.com redirect to avoid
+          # api.github.com rate limits on shared runner egress IPs.
+          latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)
+          just_version="${latest_url##*/tag/}"
+          case "$RUNNER_OS" in
+            Windows) asset="just-${just_version}-x86_64-pc-windows-msvc.zip" ;;
+            macOS)   asset="just-${just_version}-x86_64-apple-darwin.tar.gz" ;;
+            *)       asset="just-${just_version}-x86_64-unknown-linux-musl.tar.gz" ;;
+          esac
+          curl -fL "https://github.com/casey/just/releases/download/${just_version}/${asset}" -o "$install_dir/$asset"
+          case "$asset" in
+            *.zip) unzip -o "$install_dir/$asset" -d "$install_dir" ;;
+            *)     tar -xzf "$install_dir/$asset" -C "$install_dir" ;;
+          esac
+          echo "$install_dir" >> "$GITHUB_PATH"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x.x
@@ -59,7 +119,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - name: Install just
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP:-/tmp}/just-bin"
+          mkdir -p "$install_dir"
+          # Resolve the latest release tag via the github.com redirect to avoid
+          # api.github.com rate limits on shared runner egress IPs.
+          latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)
+          just_version="${latest_url##*/tag/}"
+          case "$RUNNER_OS" in
+            Windows) asset="just-${just_version}-x86_64-pc-windows-msvc.zip" ;;
+            macOS)   asset="just-${just_version}-x86_64-apple-darwin.tar.gz" ;;
+            *)       asset="just-${just_version}-x86_64-unknown-linux-musl.tar.gz" ;;
+          esac
+          curl -fL "https://github.com/casey/just/releases/download/${just_version}/${asset}" -o "$install_dir/$asset"
+          case "$asset" in
+            *.zip) unzip -o "$install_dir/$asset" -d "$install_dir" ;;
+            *)     tar -xzf "$install_dir/$asset" -C "$install_dir" ;;
+          esac
+          echo "$install_dir" >> "$GITHUB_PATH"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.x.x
@@ -101,7 +181,27 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: extractions/setup-just@v3
+      - name: Install just
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP:-/tmp}/just-bin"
+          mkdir -p "$install_dir"
+          # Resolve the latest release tag via the github.com redirect to avoid
+          # api.github.com rate limits on shared runner egress IPs.
+          latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)
+          just_version="${latest_url##*/tag/}"
+          case "$RUNNER_OS" in
+            Windows) asset="just-${just_version}-x86_64-pc-windows-msvc.zip" ;;
+            macOS)   asset="just-${just_version}-x86_64-apple-darwin.tar.gz" ;;
+            *)       asset="just-${just_version}-x86_64-unknown-linux-musl.tar.gz" ;;
+          esac
+          curl -fL "https://github.com/casey/just/releases/download/${just_version}/${asset}" -o "$install_dir/$asset"
+          case "$asset" in
+            *.zip) unzip -o "$install_dir/$asset" -d "$install_dir" ;;
+            *)     tar -xzf "$install_dir/$asset" -C "$install_dir" ;;
+          esac
+          echo "$install_dir" >> "$GITHUB_PATH"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |
@@ -153,7 +253,27 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: extractions/setup-just@v3
+      - name: Install just
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP:-/tmp}/just-bin"
+          mkdir -p "$install_dir"
+          # Resolve the latest release tag via the github.com redirect to avoid
+          # api.github.com rate limits on shared runner egress IPs.
+          latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)
+          just_version="${latest_url##*/tag/}"
+          case "$RUNNER_OS" in
+            Windows) asset="just-${just_version}-x86_64-pc-windows-msvc.zip" ;;
+            macOS)   asset="just-${just_version}-x86_64-apple-darwin.tar.gz" ;;
+            *)       asset="just-${just_version}-x86_64-unknown-linux-musl.tar.gz" ;;
+          esac
+          curl -fL "https://github.com/casey/just/releases/download/${just_version}/${asset}" -o "$install_dir/$asset"
+          case "$asset" in
+            *.zip) unzip -o "$install_dir/$asset" -d "$install_dir" ;;
+            *)     tar -xzf "$install_dir/$asset" -C "$install_dir" ;;
+          esac
+          echo "$install_dir" >> "$GITHUB_PATH"
       - uses: actions/setup-dotnet@v5
         id: setupid
         with:
@@ -189,7 +309,27 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: extractions/setup-just@v3
+      - name: Install just
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP:-/tmp}/just-bin"
+          mkdir -p "$install_dir"
+          # Resolve the latest release tag via the github.com redirect to avoid
+          # api.github.com rate limits on shared runner egress IPs.
+          latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)
+          just_version="${latest_url##*/tag/}"
+          case "$RUNNER_OS" in
+            Windows) asset="just-${just_version}-x86_64-pc-windows-msvc.zip" ;;
+            macOS)   asset="just-${just_version}-x86_64-apple-darwin.tar.gz" ;;
+            *)       asset="just-${just_version}-x86_64-unknown-linux-musl.tar.gz" ;;
+          esac
+          curl -fL "https://github.com/casey/just/releases/download/${just_version}/${asset}" -o "$install_dir/$asset"
+          case "$asset" in
+            *.zip) unzip -o "$install_dir/$asset" -d "$install_dir" ;;
+            *)     tar -xzf "$install_dir/$asset" -C "$install_dir" ;;
+          esac
+          echo "$install_dir" >> "$GITHUB_PATH"
       - uses: actions/setup-dotnet@v5
         id: setupid
         with:
@@ -225,7 +365,27 @@ jobs:
       - uses: actions/checkout@v6
         with:
           submodules: true
-      - uses: extractions/setup-just@v3
+      - name: Install just
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP:-/tmp}/just-bin"
+          mkdir -p "$install_dir"
+          # Resolve the latest release tag via the github.com redirect to avoid
+          # api.github.com rate limits on shared runner egress IPs.
+          latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)
+          just_version="${latest_url##*/tag/}"
+          case "$RUNNER_OS" in
+            Windows) asset="just-${just_version}-x86_64-pc-windows-msvc.zip" ;;
+            macOS)   asset="just-${just_version}-x86_64-apple-darwin.tar.gz" ;;
+            *)       asset="just-${just_version}-x86_64-unknown-linux-musl.tar.gz" ;;
+          esac
+          curl -fL "https://github.com/casey/just/releases/download/${just_version}/${asset}" -o "$install_dir/$asset"
+          case "$asset" in
+            *.zip) unzip -o "$install_dir/$asset" -d "$install_dir" ;;
+            *)     tar -xzf "$install_dir/$asset" -C "$install_dir" ;;
+          esac
+          echo "$install_dir" >> "$GITHUB_PATH"
       - uses: actions/setup-dotnet@v5
         id: setupid
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,27 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: extractions/setup-just@v3
+      - name: Install just
+        shell: bash
+        run: |
+          set -euo pipefail
+          install_dir="${RUNNER_TEMP:-/tmp}/just-bin"
+          mkdir -p "$install_dir"
+          # Resolve the latest release tag via the github.com redirect to avoid
+          # api.github.com rate limits on shared runner egress IPs.
+          latest_url=$(curl -fsSLI -o /dev/null -w '%{url_effective}' https://github.com/casey/just/releases/latest)
+          just_version="${latest_url##*/tag/}"
+          case "$RUNNER_OS" in
+            Windows) asset="just-${just_version}-x86_64-pc-windows-msvc.zip" ;;
+            macOS)   asset="just-${just_version}-x86_64-apple-darwin.tar.gz" ;;
+            *)       asset="just-${just_version}-x86_64-unknown-linux-musl.tar.gz" ;;
+          esac
+          curl -fL "https://github.com/casey/just/releases/download/${just_version}/${asset}" -o "$install_dir/$asset"
+          case "$asset" in
+            *.zip) unzip -o "$install_dir/$asset" -d "$install_dir" ;;
+            *)     tar -xzf "$install_dir/$asset" -C "$install_dir" ;;
+          esac
+          echo "$install_dir" >> "$GITHUB_PATH"
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: |


### PR DESCRIPTION
## What

Replaces the unverified third-party action `extractions/setup-just` with a `run` step that installs `just` directly from the official installer at `https://just.systems/install.sh`.

## Why

- `extractions/setup-just` is from an **unverified publisher** and is not on the approved list in `EasyPost/ep-actions/ApprovedThirdPartyActions.yaml`.
- This repo is **public**, so it cannot consume the private `EasyPost/ep-actions` composite action (GitHub does not allow public repos to reference actions in private repos).
- There is **no verified-publisher** GitHub Action that installs `just`.

Installing via the official script removes the third-party action dependency entirely.

## How

```yaml
- name: Install just
  shell: bash
  run: |
    mkdir -p "$HOME/.local/bin"
    curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to "$HOME/.local/bin"
    echo "$HOME/.local/bin" >> "$GITHUB_PATH"
```

`shell: bash` ensures it also runs on Windows runners (where applicable).